### PR TITLE
Snapcraft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 Cargo.lock
 test_config.json
 .idea
+*.snap

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,9 +17,9 @@ grade: stable
 confinement: strict
 
 apps:
-  ado:
+  azdocli:
     command: bin/ado
-    aliases: [azdocli, azdo, ado]
+    aliases: [adocli, azdo, ado]
 
 parts:
   azdocli:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: azdocli
 base: core22
-version: '0.2.0' # Will be updated by CI
+version: '0.2.36' # Will be updated by CI
 summary: CLI tool for interacting with Azure DevOps
 description: |
   A powerful command-line interface for Azure DevOps that provides repository 
@@ -14,11 +14,12 @@ description: |
   - Default project support
 
 grade: stable
-confinement: devmode
+confinement: strict
 
 apps:
-  azdocli:
+  ado:
     command: bin/ado
+    aliases: [azdocli, azdo, ado]
 
 parts:
   azdocli:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,25 +14,16 @@ description: |
   - Default project support
 
 grade: stable
-confinement: strict
-
-architectures:
-  - build-on: amd64
-  - build-on: arm64
+confinement: devmode
 
 apps:
   azdocli:
     command: bin/ado
-    plugs:
-      - home
-      - network
-      - network-bind
 
 parts:
   azdocli:
-    plugin: dump
+    plugin: rust
     source: .
-    stage-packages:
-      - ca-certificates
-    organize:
-      ado: bin/ado
+    build-packages:
+      - libssl-dev
+      - pkg-config

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,30 @@
+name: azdocli
+base: core22
+version: '0.2.36' # Will be updated by CI
+summary: CLI tool for interacting with Azure DevOps
+description: |
+  A powerful command-line interface for Azure DevOps that provides repository 
+  management, pipeline management, and board management capabilities.
+  
+  Features include:
+  - Repository management (list, create, delete, clone, view, and manage pull requests)
+  - Pipeline management
+  - Board management  
+  - Authentication using Personal Access Tokens (PAT)
+  - Default project support
+
+grade: stable
+confinement: strict
+
+apps:
+  azdocli:
+    command: bin/ado
+    aliases: [adocli, azdo, ado]
+
+parts:
+  azdocli:
+    plugin: rust
+    source: .
+    build-packages:
+      - libssl-dev
+      - pkg-config


### PR DESCRIPTION
This pull request updates the `snap/snapcraft.yaml` file for the `azdocli` Snap package, introducing significant improvements to its configuration, functionality, and metadata. The most important changes include updating the version, enhancing the description, modifying app aliases, and transitioning the build process to use Rust.

### Metadata Updates:
* Updated the version of the Snap package from `'0.2.0'` to `'0.2.36'` to reflect the latest release.
* Expanded the description to include detailed information about features like repository, pipeline, and board management, along with authentication and default project support.

### Functional Improvements:
* Added new aliases (`adocli`, `azdo`, `ado`) for the `azdocli` command to improve usability.

### Build Process Changes:
* Replaced the `dump` plugin with the `rust` plugin for building the Snap package, aligning with the Rust-based implementation of the tool.
* Introduced new build dependencies: `libssl-dev` and `pkg-config`, which are required for the Rust build process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced Snap package support for the CLI tool, enabling streamlined installation and management on supported systems.
  - Added command aliases for easier access to the CLI tool.

- **Chores**
  - Updated version information in Snap configuration.
  - Improved `.gitignore` to exclude `.snap` files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->