### PR TITLE
Rename binary to azdocli

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 env:
-  VERSION: 0.3.${{ github.run_number }}
+  VERSION: 0.3.1
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,8 +57,8 @@ jobs:
     - name: Zip artifacts
       shell: pwsh
       run: |
-        mv target/release/ado* ./
-        Compress-Archive ado*, README.md, LICENSE ${{ matrix.target }}.zip
+        mv target/release/azdocli* ./
+        Compress-Archive azdocli*, README.md, LICENSE ${{ matrix.target }}.zip
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 env:
-  VERSION: 0.3.0
+  VERSION: 0.3.1
 
 jobs:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,8 +46,8 @@ jobs:
     - name: Zip artifacts
       shell: pwsh
       run: |
-        mv target/release/ado* ./
-        Compress-Archive ado*, README.md, LICENSE ${{ matrix.target }}.zip
+        mv target/release/azdocli* ./
+        Compress-Archive azdocli*, README.md, LICENSE ${{ matrix.target }}.zip
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,6 @@ homepage = "https://christianhelle.com/azdocli"
 repository = "https://github.com/christianhelle/azdocli"
 readme = "src/README.md"
 
-[[bin]]
-name = "ado"
-path = "src/main.rs"
-
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ The easiest way to install azdocli is using Cargo:
 cargo install azdocli
 ```
 
-This will install the `azdocli` binary which you can use immediately.
+This will install the `azdocli` binary, which you can use immediately.
 
 ### Install from GitHub Releases
 

--- a/README.md
+++ b/README.md
@@ -20,15 +20,15 @@ eliminating the need to specify `--project` for every command:
 
 ```sh
 # Set a default project
-ado project MyDefaultProject
+azdocli project MyDefaultProject
 
 # View the current default project
-ado project
+azdocli project
 
 # All commands will now use the default project if --project is not specified
-ado repos list                  # Uses default project
-ado pipelines list              # Uses default project
-ado repos list --project Other  # Overrides default with "Other"
+azdocli repos list                  # Uses default project
+azdocli pipelines list              # Uses default project
+azdocli repos list --project Other  # Overrides default with "Other"
 ```
 
 **Default Project Features:**
@@ -46,28 +46,28 @@ The `repos clone` command allows you to clone all repositories from an Azure Dev
 
 ```sh
 # Set a default project first (optional but recommended)
-ado project MyProject
+azdocli project MyProject
 
 # Clone all repositories from the default project (with confirmation prompt)
-ado repos clone
+azdocli repos clone
 
 # Or override with a specific project
-ado repos clone --project MyProject
+azdocli repos clone --project MyProject
 
 # Clone to a specific directory
-ado repos clone --target-dir ./repos
+azdocli repos clone --target-dir ./repos
 
 # Skip confirmation prompt (useful for automation)
-ado repos clone --yes
+azdocli repos clone --yes
 
 # Clone repositories in parallel for faster execution
-ado repos clone --parallel
+azdocli repos clone --parallel
 
 # Control the number of concurrent clone operations (default: 4, max: 8)
-ado repos clone --parallel --concurrency 6
+azdocli repos clone --parallel --concurrency 6
 
 # Combine all options for maximum efficiency
-ado repos clone --target-dir ./repos --yes --parallel --concurrency 8
+azdocli repos clone --target-dir ./repos --yes --parallel --concurrency 8
 ```
 
 **Clone Features:**
@@ -87,10 +87,10 @@ The `repos show` command displays detailed information about a specific reposito
 
 ```sh
 # Show details of a repository by name (using default project)
-ado repos show --id MyRepository
+azdocli repos show --id MyRepository
 
 # Or specify a project explicitly
-ado repos show --id MyRepository --project MyProject
+azdocli repos show --id MyRepository --project MyProject
 ```
 
 **Show Features:**
@@ -107,19 +107,19 @@ The `repos delete` command allows you to delete repositories from an Azure DevOp
 
 ```sh
 # Soft delete a repository by name (using default project) - moves to recycle bin
-ado repos delete --id MyRepository
+azdocli repos delete --id MyRepository
 
 # Or specify a project explicitly
-ado repos delete --id MyRepository --project MyProject
+azdocli repos delete --id MyRepository --project MyProject
 
 # Hard delete - permanently delete after soft delete (requires manual recycle bin cleanup)
-ado repos delete --id MyRepository --hard
+azdocli repos delete --id MyRepository --hard
 
 # Skip confirmation prompt (useful for automation)
-ado repos delete --id MyRepository --yes
+azdocli repos delete --id MyRepository --yes
 
 # Combine options for automated hard delete
-ado repos delete --id MyRepository --hard --yes
+azdocli repos delete --id MyRepository --hard --yes
 ```
 
 **Delete Features:**
@@ -140,36 +140,36 @@ The `repos pr` commands allow you to manage pull requests within repositories:
 
 ```sh
 # List all pull requests for a repository (using default project)
-ado repos pr list --repo MyRepository
+azdocli repos pr list --repo MyRepository
 
 # Or specify a project explicitly
-ado repos pr list --repo MyRepository --project MyProject
+azdocli repos pr list --repo MyRepository --project MyProject
 ```
 
 ##### Show Pull Request Details
 
 ```sh
 # Show details of a specific pull request (using default project)
-ado repos pr show --repo MyRepository --id 123
+azdocli repos pr show --repo MyRepository --id 123
 
 # Or specify a project explicitly
-ado repos pr show --repo MyRepository --id 123 --project MyProject
+azdocli repos pr show --repo MyRepository --id 123 --project MyProject
 ```
 
 ##### Create Pull Request
 
 ```sh
 # Create a new pull request with source and target branches (using default project)
-ado repos pr create --repo MyRepository --source "feature/my-feature" --target "main" --title "My Feature" --description "Description"
+azdocli repos pr create --repo MyRepository --source "feature/my-feature" --target "main" --title "My Feature" --description "Description"
 
 # Create with minimal information - target defaults to 'main'
-ado repos pr create --repo MyRepository --source "feature/my-feature" --title "My Feature"
+azdocli repos pr create --repo MyRepository --source "feature/my-feature" --title "My Feature"
 
 # Or specify a project explicitly
-ado repos pr create --repo MyRepository --source "feature/my-feature" --target "develop" --title "My Feature" --description "Description" --project MyProject
+azdocli repos pr create --repo MyRepository --source "feature/my-feature" --target "develop" --title "My Feature" --description "Description" --project MyProject
 
 # Source branch is required, target defaults to 'main' if not specified
-ado repos pr create --repo MyRepository --source "bugfix/fix-login"
+azdocli repos pr create --repo MyRepository --source "bugfix/fix-login"
 ```
 
 **Pull Request Features:**
@@ -192,10 +192,10 @@ The `pipelines list` command allows you to list all pipelines in an Azure DevOps
 
 ```sh
 # List all pipelines in the default project
-ado pipelines list
+azdocli pipelines list
 
 # Or specify a project explicitly
-ado pipelines list --project MyProject
+azdocli pipelines list --project MyProject
 ```
 
 **List Features:**
@@ -210,10 +210,10 @@ The `pipelines runs` command shows all builds (runs) of a specified pipeline:
 
 ```sh
 # Show all runs for a pipeline (using default project)
-ado pipelines runs --id 42
+azdocli pipelines runs --id 42
 
 # Or specify a project explicitly
-ado pipelines runs --id 42 --project MyProject
+azdocli pipelines runs --id 42 --project MyProject
 ```
 
 **Runs Features:**
@@ -228,10 +228,10 @@ The `pipelines show` command displays detailed information about a specific pipe
 
 ```sh
 # Show details of a specific pipeline build (using default project)
-ado pipelines show --id 42 --build-id 123
+azdocli pipelines show --id 42 --build-id 123
 
 # Or specify a project explicitly
-ado pipelines show --id 42 --project MyProject --build-id 123
+azdocli pipelines show --id 42 --project MyProject --build-id 123
 ```
 
 **Show Features:**
@@ -246,10 +246,10 @@ The `pipelines run` command starts a new pipeline run:
 
 ```sh
 # Run a pipeline (using default project)
-ado pipelines run --id 42
+azdocli pipelines run --id 42
 
 # Or specify a project explicitly
-ado pipelines run --id 42 --project MyProject
+azdocli pipelines run --id 42 --project MyProject
 ```
 
 **Run Features:**
@@ -266,26 +266,26 @@ The `boards work-item` commands allow you to manage work items in an Azure DevOp
 
 ```sh
 # Show details of a specific work item (using default project)
-ado boards work-item show --id 123
+azdocli boards work-item show --id 123
 
 # Open work item directly in web browser
-ado boards work-item show --id 123 --web
+azdocli boards work-item show --id 123 --web
 
 # Or specify a project explicitly
-ado boards work-item show --id 123 --project MyProject
+azdocli boards work-item show --id 123 --project MyProject
 
 # Create a new work item (using default project)
 # Supported types: bug, task, user-story, feature, epic
-ado boards work-item create bug --title "Fix login issue" --description "Users cannot login after password change"
+azdocli boards work-item create bug --title "Fix login issue" --description "Users cannot login after password change"
 
 # Update a work item (using default project)
-ado boards work-item update --id 123 --title "New title" --state "Active" --priority 2
+azdocli boards work-item update --id 123 --title "New title" --state "Active" --priority 2
 
 # Delete a work item permanently (using default project)
-ado boards work-item delete --id 123
+azdocli boards work-item delete --id 123
 
 # Soft delete a work item by changing state to "Removed"
-ado boards work-item delete --id 123 --soft-delete
+azdocli boards work-item delete --id 123 --soft-delete
 ```
 
 **Work Item Features:**
@@ -302,7 +302,7 @@ ado boards work-item delete --id 123 --soft-delete
 CLI tool for interacting with Azure DevOps
 
 USAGE:
-    ado [SUBCOMMAND]
+    azdocli [SUBCOMMAND]
 
 OPTIONS:
     -h, --help       Print help information
@@ -327,7 +327,7 @@ The easiest way to install azdocli is using Cargo:
 cargo install azdocli
 ```
 
-This will install the `ado` binary which you can use immediately.
+This will install the `azdocli` binary which you can use immediately.
 
 ### Install from GitHub Releases
 
@@ -379,32 +379,32 @@ First, login to Azure DevOps using the PAT you created:
 
 ```sh
 # Login with your Personal Access Token
-ado login
+azdocli login
 # You'll be prompted for:
 # - Organization name (e.g., "mycompany" from https://dev.azure.com/mycompany)
 # - Personal Access Token (the PAT you created above)
 
 # Set a default project (optional but recommended)
-ado project MyProject
+azdocli project MyProject
 ```
 
 ### Basic Examples
 
 ```sh
 # Repository management
-ado repos list                           # List all repositories
-ado repos show --id MyRepo               # Show repository details
-ado repos clone                          # Clone all repositories
+azdocli repos list                           # List all repositories
+azdocli repos show --id MyRepo               # Show repository details
+azdocli repos clone                          # Clone all repositories
 
 # Pull request management
-ado repos pr list --repo MyRepo          # List pull requests for a repository
-ado repos pr show --repo MyRepo --id 123 # Show pull request details
-ado repos pr create --repo MyRepo --source "feature/my-feature" --title "My Feature" # Create a new pull request
+azdocli repos pr list --repo MyRepo          # List pull requests for a repository
+azdocli repos pr show --repo MyRepo --id 123 # Show pull request details
+azdocli repos pr create --repo MyRepo --source "feature/my-feature" --title "My Feature" # Create a new pull request
 
 # Pipeline management
-ado pipelines list                       # List all pipelines
-ado pipelines runs --id 42               # Show pipeline runs
-ado pipelines show --id 42 --build-id 123 # Show build details
+azdocli pipelines list                       # List all pipelines
+azdocli pipelines runs --id 42               # Show pipeline runs
+azdocli pipelines show --id 42 --build-id 123 # Show build details
 ```
 
 For detailed examples and features, see the respective sections below.

--- a/docs/index.html
+++ b/docs/index.html
@@ -73,7 +73,7 @@
                 <div class="install-card">
                     <h3>From crates.io</h3>
                     <pre><code>cargo install azdocli</code></pre>
-                    <p>The easiest way to install. This will install the <code>ado</code> binary.</p>
+                    <p>The easiest way to install. This will install the <code>azdocli</code> binary.</p>
                 </div>
                 <div class="install-card">
                     <h3>From GitHub Releases</h3>
@@ -105,27 +105,27 @@
                 </div>
                 <div class="step">
                     <h3>2. Login to Azure DevOps</h3>
-                    <pre><code>ado login</code></pre>
+                    <pre><code>azdocli login</code></pre>
                     <p>Enter your organization name and the PAT you created in step 1 when prompted.</p>
                 </div>
                 <div class="step">
                     <h3>3. Set a default project (optional)</h3>
-                    <pre><code>ado project MyProject</code></pre>
+                    <pre><code>azdocli project MyProject</code></pre>
                 </div>
                 <div class="step">
                     <h3>4. Start using the CLI</h3>
                     <pre><code># Repository management
-ado repos list
-ado repos show --id MyRepo
-ado repos clone
+azdocli repos list
+azdocli repos show --id MyRepo
+azdocli repos clone
 
 # Pull request management  
-ado repos pr list --repo MyRepo
-ado repos pr create --repo MyRepo --source "feature/my-feature" --title "My Feature"
+azdocli repos pr list --repo MyRepo
+azdocli repos pr create --repo MyRepo --source "feature/my-feature" --title "My Feature"
 
 # Pipeline management
-ado pipelines list
-ado pipelines runs --id 42</code></pre>
+azdocli pipelines list
+azdocli pipelines runs --id 42</code></pre>
                 </div>
             </div>
         </section>

--- a/docs/user-guide.html
+++ b/docs/user-guide.html
@@ -88,7 +88,7 @@
                 
                 <div class="command-example">
                     <h4>Login to Azure DevOps</h4>
-                    <pre><code>ado login</code></pre>
+                    <pre><code>azdocli login</code></pre>
                     <p>This command will prompt you to enter:</p>
                     <ul>
                         <li><strong>Azure DevOps organization name:</strong> Just the organization name (e.g., "mycompany" from https://dev.azure.com/mycompany)</li>
@@ -99,7 +99,7 @@
 
                 <div class="command-example">
                     <h4>Logout from Azure DevOps</h4>
-                    <pre><code>ado logout</code></pre>
+                    <pre><code>azdocli logout</code></pre>
                     <p>Clears stored credentials and logs you out of Azure DevOps.</p>
                 </div>
             </div>
@@ -113,12 +113,12 @@
 
                 <div class="command-example">
                     <h4>Set a default project</h4>
-                    <pre><code>ado project MyDefaultProject</code></pre>
+                    <pre><code>azdocli project MyDefaultProject</code></pre>
                 </div>
 
                 <div class="command-example">
                     <h4>View the current default project</h4>
-                    <pre><code>ado project</code></pre>
+                    <pre><code>azdocli project</code></pre>
                 </div>
 
                 <h4>Features:</h4>
@@ -140,28 +140,28 @@
                 <div class="command-example">
                     <h4>List all repositories</h4>
                     <pre><code># List repositories in default project
-ado repos list
+azdocli repos list
 
 # List repositories in specific project
-ado repos list --project MyProject</code></pre>
+azdocli repos list --project MyProject</code></pre>
                 </div>
 
                 <div class="command-example">
                     <h4>Create a new repository</h4>
                     <pre><code># Create repository in default project
-ado repos create --name MyNewRepo
+azdocli repos create --name MyNewRepo
 
 # Create repository in specific project
-ado repos create --name MyNewRepo --project MyProject</code></pre>
+azdocli repos create --name MyNewRepo --project MyProject</code></pre>
                 </div>
 
                 <div class="command-example">
                     <h4>Show repository details</h4>
                     <pre><code># Show details using default project
-ado repos show --id MyRepository
+azdocli repos show --id MyRepository
 
 # Show details with specific project
-ado repos show --id MyRepository --project MyProject</code></pre>
+azdocli repos show --id MyRepository --project MyProject</code></pre>
                 </div>
 
                 <h4>Show Features:</h4>
@@ -181,28 +181,28 @@ ado repos show --id MyRepository --project MyProject</code></pre>
                 <div class="command-example">
                     <h4>Basic cloning</h4>
                     <pre><code># Clone all repositories from default project (with confirmation prompt)
-ado repos clone
+azdocli repos clone
 
 # Clone from specific project
-ado repos clone --project MyProject</code></pre>
+azdocli repos clone --project MyProject</code></pre>
                 </div>
 
                 <div class="command-example">
                     <h4>Advanced cloning options</h4>
                     <pre><code># Clone to specific directory
-ado repos clone --target-dir ./repos
+azdocli repos clone --target-dir ./repos
 
 # Skip confirmation prompt (useful for automation)
-ado repos clone --yes
+azdocli repos clone --yes
 
 # Clone repositories in parallel for faster execution
-ado repos clone --parallel
+azdocli repos clone --parallel
 
 # Control concurrent operations (default: 4, max: 8)
-ado repos clone --parallel --concurrency 6
+azdocli repos clone --parallel --concurrency 6
 
 # Combine all options for maximum efficiency
-ado repos clone --target-dir ./repos --yes --parallel --concurrency 8</code></pre>
+azdocli repos clone --target-dir ./repos --yes --parallel --concurrency 8</code></pre>
                 </div>
 
                 <h4>Clone Features:</h4>
@@ -225,19 +225,19 @@ ado repos clone --target-dir ./repos --yes --parallel --concurrency 8</code></pr
                 <div class="command-example">
                     <h4>Delete operations</h4>
                     <pre><code># Soft delete (moves to recycle bin)
-ado repos delete --id MyRepository
+azdocli repos delete --id MyRepository
 
 # Specify project explicitly
-ado repos delete --id MyRepository --project MyProject
+azdocli repos delete --id MyRepository --project MyProject
 
 # Hard delete (permanent deletion)
-ado repos delete --id MyRepository --hard
+azdocli repos delete --id MyRepository --hard
 
 # Skip confirmation prompt (automation)
-ado repos delete --id MyRepository --yes
+azdocli repos delete --id MyRepository --yes
 
 # Combine options for automated hard delete
-ado repos delete --id MyRepository --hard --yes</code></pre>
+azdocli repos delete --id MyRepository --hard --yes</code></pre>
                 </div>
 
                 <h4>Delete Features:</h4>
@@ -258,34 +258,34 @@ ado repos delete --id MyRepository --hard --yes</code></pre>
                 <div class="command-example">
                     <h4>List Pull Requests</h4>
                     <pre><code># List all pull requests for a repository
-ado repos pr list --repo MyRepository
+azdocli repos pr list --repo MyRepository
 
 # With specific project
-ado repos pr list --repo MyRepository --project MyProject</code></pre>
+azdocli repos pr list --repo MyRepository --project MyProject</code></pre>
                 </div>
 
                 <div class="command-example">
                     <h4>Show Pull Request Details</h4>
                     <pre><code># Show details of a specific pull request
-ado repos pr show --repo MyRepository --id 123
+azdocli repos pr show --repo MyRepository --id 123
 
 # With specific project
-ado repos pr show --repo MyRepository --id 123 --project MyProject</code></pre>
+azdocli repos pr show --repo MyRepository --id 123 --project MyProject</code></pre>
                 </div>
 
                 <div class="command-example">
                     <h4>Create Pull Request</h4>
                     <pre><code># Create with full details
-ado repos pr create --repo MyRepository --source "feature/my-feature" --target "main" --title "My Feature" --description "Description"
+azdocli repos pr create --repo MyRepository --source "feature/my-feature" --target "main" --title "My Feature" --description "Description"
 
 # Create with minimal information (target defaults to 'main')
-ado repos pr create --repo MyRepository --source "feature/my-feature" --title "My Feature"
+azdocli repos pr create --repo MyRepository --source "feature/my-feature" --title "My Feature"
 
 # With specific project
-ado repos pr create --repo MyRepository --source "feature/my-feature" --target "develop" --title "My Feature" --project MyProject
+azdocli repos pr create --repo MyRepository --source "feature/my-feature" --target "develop" --title "My Feature" --project MyProject
 
 # Source branch is required, target defaults to 'main'
-ado repos pr create --repo MyRepository --source "bugfix/fix-login"</code></pre>
+azdocli repos pr create --repo MyRepository --source "bugfix/fix-login"</code></pre>
                 </div>
 
                 <h4>Pull Request Features:</h4>
@@ -311,40 +311,40 @@ ado repos pr create --repo MyRepository --source "bugfix/fix-login"</code></pre>
                 <div class="command-example">
                     <h4>List Pipelines</h4>
                     <pre><code># List all pipelines in default project
-ado pipelines list
+azdocli pipelines list
 
 # List pipelines in specific project
-ado pipelines list --project MyProject</code></pre>
+azdocli pipelines list --project MyProject</code></pre>
                     <p><strong>Features</strong>: Comprehensive listing with IDs and names in user-friendly table format.</p>
                 </div>
 
                 <div class="command-example">
                     <h4>Show Pipeline Runs</h4>
                     <pre><code># Show all runs for a pipeline
-ado pipelines runs --id 42
+azdocli pipelines runs --id 42
 
 # With specific project
-ado pipelines runs --id 42 --project MyProject</code></pre>
+azdocli pipelines runs --id 42 --project MyProject</code></pre>
                     <p><strong>Features</strong>: View run history, status visibility, and clear display of run information.</p>
                 </div>
 
                 <div class="command-example">
                     <h4>Show Pipeline Build Details</h4>
                     <pre><code># Show details of a specific pipeline build
-ado pipelines show --id 42 --build-id 123
+azdocli pipelines show --id 42 --build-id 123
 
 # With specific project
-ado pipelines show --id 42 --project MyProject --build-id 123</code></pre>
+azdocli pipelines show --id 42 --project MyProject --build-id 123</code></pre>
                     <p><strong>Features</strong>: Detailed information about builds, debug information for troubleshooting.</p>
                 </div>
 
                 <div class="command-example">
                     <h4>Run Pipeline</h4>
                     <pre><code># Start a new pipeline run
-ado pipelines run --id 42
+azdocli pipelines run --id 42
 
 # With specific project
-ado pipelines run --id 42 --project MyProject</code></pre>
+azdocli pipelines run --id 42 --project MyProject</code></pre>
                     <p><strong>Features</strong>: Pipeline execution with real-time updates and clear error feedback.</p>
                 </div>
             </div>
@@ -360,39 +360,39 @@ ado pipelines run --id 42 --project MyProject</code></pre>
                 <div class="command-example">
                     <h4>Show Work Item</h4>
                     <pre><code># Show details of a work item
-ado boards work-item show --id 123
+azdocli boards work-item show --id 123
 
 # Open work item directly in web browser
-ado boards work-item show --id 123 --web
+azdocli boards work-item show --id 123 --web
 
 # With specific project
-ado boards work-item show --id 123 --project MyProject</code></pre>
+azdocli boards work-item show --id 123 --project MyProject</code></pre>
                 </div>
 
                 <div class="command-example">
                     <h4>Create Work Item</h4>
                     <pre><code># Create different types of work items
-ado boards work-item create bug --title "Fix login issue" --description "Users cannot login after password change"
-ado boards work-item create task --title "Update documentation"
-ado boards work-item create user-story --title "User registration feature"
-ado boards work-item create feature --title "New reporting dashboard"
-ado boards work-item create epic --title "Mobile application development"</code></pre>
+azdocli boards work-item create bug --title "Fix login issue" --description "Users cannot login after password change"
+azdocli boards work-item create task --title "Update documentation"
+azdocli boards work-item create user-story --title "User registration feature"
+azdocli boards work-item create feature --title "New reporting dashboard"
+azdocli boards work-item create epic --title "Mobile application development"</code></pre>
                     <p>Supported types: bug, task, user-story, feature, epic</p>
                 </div>
 
                 <div class="command-example">
                     <h4>Update Work Item</h4>
                     <pre><code># Update work item fields
-ado boards work-item update --id 123 --title "New title" --state "Active" --priority 2</code></pre>
+azdocli boards work-item update --id 123 --title "New title" --state "Active" --priority 2</code></pre>
                 </div>
 
                 <div class="command-example">
                     <h4>Delete Work Item</h4>
                     <pre><code># Permanent delete
-ado boards work-item delete --id 123
+azdocli boards work-item delete --id 123
 
 # Soft delete (changes state to "Removed")
-ado boards work-item delete --id 123 --soft-delete</code></pre>
+azdocli boards work-item delete --id 123 --soft-delete</code></pre>
                 </div>
 
                 <h4>Work Item Features:</h4>

--- a/homebrew/azdocli.rb
+++ b/homebrew/azdocli.rb
@@ -12,12 +12,12 @@ class Azdocli < Formula
   end
 
   def install
-    bin.install "ado" => "ado"
+    bin.install "azdocli" => "azdocli"
     doc.install "README.md"
     (share/"licenses"/name).install "LICENSE"
   end
 
   test do
-    system "#{bin}/ado", "--help"
+    system "#{bin}/azdocli", "--help"
   end
 end

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -19,7 +19,7 @@ confinement: strict
 apps:
   azdocli:
     command: bin/azdocli
-    aliases: [ado, azdo, azdocli]
+    aliases: [ado, azdo, adocli]
 
 parts:
   azdocli:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -18,8 +18,8 @@ confinement: strict
 
 apps:
   azdocli:
-    command: bin/ado
-    aliases: [adocli, azdo, ado]
+    command: bin/azdocli
+    aliases: [ado, azdo, azdocli]
 
 parts:
   azdocli:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: azdocli
 base: core22
-version: '0.3.0' # Will be updated by CI
+version: '0.3.1'
 summary: CLI tool for interacting with Azure DevOps
 description: |
   A powerful command-line interface for Azure DevOps that provides repository 

--- a/src/README.md
+++ b/src/README.md
@@ -17,15 +17,15 @@ eliminating the need to specify `--project` for every command:
 
 ```sh
 # Set a default project
-ado project MyDefaultProject
+azdocli project MyDefaultProject
 
 # View the current default project
-ado project
+azdocli project
 
 # All commands will now use the default project if --project is not specified
-ado repos list                  # Uses default project
-ado pipelines list              # Uses default project
-ado repos list --project Other  # Overrides default with "Other"
+azdocli repos list                  # Uses default project
+azdocli pipelines list              # Uses default project
+azdocli repos list --project Other  # Overrides default with "Other"
 ```
 
 **Default Project Features:**
@@ -43,28 +43,28 @@ The `repos clone` command allows you to clone all repositories from an Azure Dev
 
 ```sh
 # Set a default project first (optional but recommended)
-ado project MyProject
+azdocli project MyProject
 
 # Clone all repositories from the default project (with confirmation prompt)
-ado repos clone
+azdocli repos clone
 
 # Or override with a specific project
-ado repos clone --project MyProject
+azdocli repos clone --project MyProject
 
 # Clone to a specific directory
-ado repos clone --target-dir ./repos
+azdocli repos clone --target-dir ./repos
 
 # Skip confirmation prompt (useful for automation)
-ado repos clone --yes
+azdocli repos clone --yes
 
 # Clone repositories in parallel for faster execution
-ado repos clone --parallel
+azdocli repos clone --parallel
 
 # Control the number of concurrent clone operations (default: 4, max: 8)
-ado repos clone --parallel --concurrency 6
+azdocli repos clone --parallel --concurrency 6
 
 # Combine all options for maximum efficiency
-ado repos clone --target-dir ./repos --yes --parallel --concurrency 8
+azdocli repos clone --target-dir ./repos --yes --parallel --concurrency 8
 ```
 
 **Clone Features:**
@@ -84,10 +84,10 @@ The `repos show` command displays detailed information about a specific reposito
 
 ```sh
 # Show details of a repository by name (using default project)
-ado repos show --id MyRepository
+azdocli repos show --id MyRepository
 
 # Or specify a project explicitly
-ado repos show --id MyRepository --project MyProject
+azdocli repos show --id MyRepository --project MyProject
 ```
 
 **Show Features:**
@@ -104,19 +104,19 @@ The `repos delete` command allows you to delete repositories from an Azure DevOp
 
 ```sh
 # Soft delete a repository by name (using default project) - moves to recycle bin
-ado repos delete --id MyRepository
+azdocli repos delete --id MyRepository
 
 # Or specify a project explicitly
-ado repos delete --id MyRepository --project MyProject
+azdocli repos delete --id MyRepository --project MyProject
 
 # Hard delete - permanently delete after soft delete (requires manual recycle bin cleanup)
-ado repos delete --id MyRepository --hard
+azdocli repos delete --id MyRepository --hard
 
 # Skip confirmation prompt (useful for automation)
-ado repos delete --id MyRepository --yes
+azdocli repos delete --id MyRepository --yes
 
 # Combine options for automated hard delete
-ado repos delete --id MyRepository --hard --yes
+azdocli repos delete --id MyRepository --hard --yes
 ```
 
 **Delete Features:**
@@ -137,36 +137,36 @@ The `repos pr` commands allow you to manage pull requests within repositories:
 
 ```sh
 # List all pull requests for a repository (using default project)
-ado repos pr list --repo MyRepository
+azdocli repos pr list --repo MyRepository
 
 # Or specify a project explicitly
-ado repos pr list --repo MyRepository --project MyProject
+azdocli repos pr list --repo MyRepository --project MyProject
 ```
 
 ##### Show Pull Request Details
 
 ```sh
 # Show details of a specific pull request (using default project)
-ado repos pr show --repo MyRepository --id 123
+azdocli repos pr show --repo MyRepository --id 123
 
 # Or specify a project explicitly
-ado repos pr show --repo MyRepository --id 123 --project MyProject
+azdocli repos pr show --repo MyRepository --id 123 --project MyProject
 ```
 
 ##### Create Pull Request
 
 ```sh
 # Create a new pull request with source and target branches (using default project)
-ado repos pr create --repo MyRepository --source "feature/my-feature" --target "main" --title "My Feature" --description "Description"
+azdocli repos pr create --repo MyRepository --source "feature/my-feature" --target "main" --title "My Feature" --description "Description"
 
 # Create with minimal information - target defaults to 'main'
-ado repos pr create --repo MyRepository --source "feature/my-feature" --title "My Feature"
+azdocli repos pr create --repo MyRepository --source "feature/my-feature" --title "My Feature"
 
 # Or specify a project explicitly
-ado repos pr create --repo MyRepository --source "feature/my-feature" --target "develop" --title "My Feature" --description "Description" --project MyProject
+azdocli repos pr create --repo MyRepository --source "feature/my-feature" --target "develop" --title "My Feature" --description "Description" --project MyProject
 
 # Source branch is required, target defaults to 'main' if not specified
-ado repos pr create --repo MyRepository --source "bugfix/fix-login"
+azdocli repos pr create --repo MyRepository --source "bugfix/fix-login"
 ```
 
 **Pull Request Features:**
@@ -189,10 +189,10 @@ The `pipelines list` command allows you to list all pipelines in an Azure DevOps
 
 ```sh
 # List all pipelines in the default project
-ado pipelines list
+azdocli pipelines list
 
 # Or specify a project explicitly
-ado pipelines list --project MyProject
+azdocli pipelines list --project MyProject
 ```
 
 **List Features:**
@@ -207,10 +207,10 @@ The `pipelines runs` command shows all builds (runs) of a specified pipeline:
 
 ```sh
 # Show all runs for a pipeline (using default project)
-ado pipelines runs --id 42
+azdocli pipelines runs --id 42
 
 # Or specify a project explicitly
-ado pipelines runs --id 42 --project MyProject
+azdocli pipelines runs --id 42 --project MyProject
 ```
 
 **Runs Features:**
@@ -225,10 +225,10 @@ The `pipelines show` command displays detailed information about a specific pipe
 
 ```sh
 # Show details of a specific pipeline build (using default project)
-ado pipelines show --id 42 --build-id 123
+azdocli pipelines show --id 42 --build-id 123
 
 # Or specify a project explicitly
-ado pipelines show --id 42 --project MyProject --build-id 123
+azdocli pipelines show --id 42 --project MyProject --build-id 123
 ```
 
 **Show Features:**
@@ -243,10 +243,10 @@ The `pipelines run` command starts a new pipeline run:
 
 ```sh
 # Run a pipeline (using default project)
-ado pipelines run --id 42
+azdocli pipelines run --id 42
 
 # Or specify a project explicitly
-ado pipelines run --id 42 --project MyProject
+azdocli pipelines run --id 42 --project MyProject
 ```
 
 **Run Features:**
@@ -263,26 +263,26 @@ The `boards work-item` commands allow you to manage work items in an Azure DevOp
 
 ```sh
 # Show details of a specific work item (using default project)
-ado boards work-item show --id 123
+azdocli boards work-item show --id 123
 
 # Open work item directly in web browser
-ado boards work-item show --id 123 --web
+azdocli boards work-item show --id 123 --web
 
 # Or specify a project explicitly
-ado boards work-item show --id 123 --project MyProject
+azdocli boards work-item show --id 123 --project MyProject
 
 # Create a new work item (using default project)
 # Supported types: bug, task, user-story, feature, epic
-ado boards work-item create bug --title "Fix login issue" --description "Users cannot login after password change"
+azdocli boards work-item create bug --title "Fix login issue" --description "Users cannot login after password change"
 
 # Update a work item (using default project)
-ado boards work-item update --id 123 --title "New title" --state "Active" --priority 2
+azdocli boards work-item update --id 123 --title "New title" --state "Active" --priority 2
 
 # Delete a work item permanently (using default project)
-ado boards work-item delete --id 123
+azdocli boards work-item delete --id 123
 
 # Soft delete a work item by changing state to "Removed"
-ado boards work-item delete --id 123 --soft-delete
+azdocli boards work-item delete --id 123 --soft-delete
 ```
 
 **Work Item Features:**
@@ -299,7 +299,7 @@ ado boards work-item delete --id 123 --soft-delete
 CLI tool for interacting with Azure DevOps
 
 USAGE:
-    ado [SUBCOMMAND]
+    azdocli [SUBCOMMAND]
 
 OPTIONS:
     -h, --help       Print help information
@@ -324,7 +324,7 @@ The easiest way to install azdocli is using Cargo:
 cargo install azdocli
 ```
 
-This will install the `ado` binary which you can use immediately.
+This will install the `azdocli` binary which you can use immediately.
 
 ### Install from GitHub Releases
 
@@ -376,32 +376,32 @@ First, login to Azure DevOps using the PAT you created:
 
 ```sh
 # Login with your Personal Access Token
-ado login
+azdocli login
 # You'll be prompted for:
 # - Organization name (e.g., "mycompany" from https://dev.azure.com/mycompany)
 # - Personal Access Token (the PAT you created above)
 
 # Set a default project (optional but recommended)
-ado project MyProject
+azdocli project MyProject
 ```
 
 ### Basic Examples
 
 ```sh
 # Repository management
-ado repos list                           # List all repositories
-ado repos show --id MyRepo               # Show repository details
-ado repos clone                          # Clone all repositories
+azdocli repos list                           # List all repositories
+azdocli repos show --id MyRepo               # Show repository details
+azdocli repos clone                          # Clone all repositories
 
 # Pull request management
-ado repos pr list --repo MyRepo          # List pull requests for a repository
-ado repos pr show --repo MyRepo --id 123 # Show pull request details
-ado repos pr create --repo MyRepo --source "feature/my-feature" --title "My Feature" # Create a new pull request
+azdocli repos pr list --repo MyRepo          # List pull requests for a repository
+azdocli repos pr show --repo MyRepo --id 123 # Show pull request details
+azdocli repos pr create --repo MyRepo --source "feature/my-feature" --title "My Feature" # Create a new pull request
 
 # Pipeline management
-ado pipelines list                       # List all pipelines
-ado pipelines runs --id 42               # Show pipeline runs
-ado pipelines show --id 42 --build-id 123 # Show build details
+azdocli pipelines list                       # List all pipelines
+azdocli pipelines runs --id 42               # Show pipeline runs
+azdocli pipelines show --id 42 --build-id 123 # Show build details
 ```
 
 For detailed examples and features, see the respective sections below.

--- a/src/README.md
+++ b/src/README.md
@@ -324,7 +324,7 @@ The easiest way to install azdocli is using Cargo:
 cargo install azdocli
 ```
 
-This will install the `azdocli` binary which you can use immediately.
+This will install the `azdocli` binary, which you can use immediately.
 
 ### Install from GitHub Releases
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -81,7 +81,7 @@ fn get_pat() -> Result<String> {
 
     if !creds_path.exists() {
         return Err(anyhow!(
-            "Not logged in. Please login first with 'ado login'"
+            "Not logged in. Please login first with 'azdocli login'"
         ));
     }
 

--- a/src/project.rs
+++ b/src/project.rs
@@ -23,7 +23,7 @@ pub fn get_default_project() -> anyhow::Result<String> {
     let config_file = config_dir.join("config.json");
 
     if !config_file.exists() {
-        return Err(anyhow!("No default project configured. Please set one using 'ado project <project_name>' or use the --project argument"));
+        return Err(anyhow!("No default project configured. Please set one using 'azdocli project <project_name>' or use the --project argument"));
     }
 
     let config_content = fs::read_to_string(config_file)?;
@@ -31,7 +31,7 @@ pub fn get_default_project() -> anyhow::Result<String> {
 
     match config["default_project"].as_str() {
         Some(project) => Ok(project.to_string()),
-        None => Err(anyhow!("No default project configured. Please set one using 'ado project <project_name>' or use the --project argument"))
+        None => Err(anyhow!("No default project configured. Please set one using 'azdocli project <project_name>' or use the --project argument"))
     }
 }
 

--- a/test_commands.ps1
+++ b/test_commands.ps1
@@ -1,7 +1,7 @@
-# Test script for ado commands
+# Test script for azdocli commands
 # This script tests the command-line interface without requiring actual Azure DevOps authentication
 
-Write-Host "Testing ado command-line interface..." -ForegroundColor Green
+Write-Host "Testing azdocli command-line interface..." -ForegroundColor Green
 
 # Build the project first
 Write-Host "`nBuilding project..." -ForegroundColor Yellow
@@ -11,7 +11,7 @@ if ($LASTEXITCODE -ne 0) {
     exit 1
 }
 
-$exe = ".\target\debug\ado.exe"
+$exe = ".\target\debug\azdocli.exe"
 
 Write-Host "`nTesting main help..." -ForegroundColor Yellow
 & $exe --help

--- a/winget/ChristianHelle.AzureDevOpsCLI.installer.yaml
+++ b/winget/ChristianHelle.AzureDevOpsCLI.installer.yaml
@@ -10,7 +10,7 @@ InstallModes:
 - silentWithProgress
 UpgradeBehavior: install
 Commands:
-- ado
+- azdocli
 FileExtensions:
 - yml
 - yaml
@@ -20,16 +20,16 @@ Installers:
   InstallerType: zip
   NestedInstallerType: portable
   NestedInstallerFiles:
-  - RelativeFilePath: ado.exe
-    PortableCommandAlias: ado
+  - RelativeFilePath: azdocli.exe
+    PortableCommandAlias: azdocli
   InstallerUrl: https://github.com/christianhelle/azdocli/releases/download/VERSION_PLACEHOLDER/windows-x64.zip
   InstallerSha256: SHA256_X64_PLACEHOLDER
 - Architecture: arm64
   InstallerType: zip
   NestedInstallerType: portable
   NestedInstallerFiles:
-  - RelativeFilePath: ado.exe
-    PortableCommandAlias: ado
+  - RelativeFilePath: azdocli.exe
+    PortableCommandAlias: azdocli
   InstallerUrl: https://github.com/christianhelle/azdocli/releases/download/VERSION_PLACEHOLDER/windows-arm64.zip
   InstallerSha256: SHA256_ARM64_PLACEHOLDER
 ManifestType: installer


### PR DESCRIPTION
This pull request rebrands the CLI tool from `ado` to `azdocli`, updates versioning in workflows, and removes the `ado` binary definition. The changes span across documentation, configuration files, and code examples to reflect the new name.

### Rebranding from `ado` to `azdocli`:

* Updated all references to the CLI tool name in the `README.md` file, including command examples for repository, pipeline, pull request, and work item management. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L23-R31) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L49-R70) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L90-R93) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L110-R122) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L143-R172) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L195-R198) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L213-R216) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L231-R234) [[9]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L249-R252) [[10]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L269-R288) [[11]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L305-R305) [[12]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L330-R330) [[13]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L382-R407)
* Updated `docs/index.html` and `docs/user-guide.html` to replace `ado` with `azdocli` in installation instructions, login/logout commands, and project/repository management examples. [[1]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL76-R76) [[2]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL108-R128) [[3]](diffhunk://#diff-cdfb783839b689d2404f69c12eb560bbb55ecc04b2f46d4df0cb8feef783a7b6L91-R91) [[4]](diffhunk://#diff-cdfb783839b689d2404f69c12eb560bbb55ecc04b2f46d4df0cb8feef783a7b6L102-R102) [[5]](diffhunk://#diff-cdfb783839b689d2404f69c12eb560bbb55ecc04b2f46d4df0cb8feef783a7b6L116-R121) [[6]](diffhunk://#diff-cdfb783839b689d2404f69c12eb560bbb55ecc04b2f46d4df0cb8feef783a7b6L143-R164)

### Workflow updates:

* Changed the `VERSION` environment variable in `.github/workflows/build.yml` and `.github/workflows/release.yml` to `0.3.1` for the new release. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L12-R12) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L7-R7)
* Updated artifact naming in the build and release workflows to use `azdocli` instead of `ado`. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L60-R61) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L49-R50)

### Removal of `ado` binary:

* Removed the `ado` binary definition from `Cargo.toml`, reflecting the transition to `azdocli`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the CLI tool name from "ado" to "azdocli" across all documentation, user guides, installation scripts, error messages, and test scripts.
- **Documentation**
	- All command examples, usage instructions, and installation notes now reference "azdocli" instead of "ado" for consistency.
- **Chores**
	- Version updated to 0.3.1 in configuration and packaging files.
	- Installation scripts and package manifests now install and reference "azdocli" as the primary binary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->