### PR TITLE
Add snap installation instructions to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,16 @@ cargo install azdocli
 
 This will install the `azdocli` binary, which you can use immediately.
 
+### Install using Snap (Linux)
+
+On Linux systems with Snap support, you can install azdocli directly from the Snap Store:
+
+```bash
+snap install azdocli
+```
+
+This will install the latest stable version and automatically handle updates.
+
 ### Install from GitHub Releases
 
 You can also download pre-built binaries from the [GitHub Releases page](https://github.com/christianhelle/azdocli/releases):

--- a/docs/index.html
+++ b/docs/index.html
@@ -65,7 +65,8 @@
                     <p>Built with Rust for exceptional performance, with parallel operations and efficient resource utilization.</p>
                 </div>
             </div>
-        </section>        <section id="installation">
+        </section>
+        <section id="installation">
             <h2>📦 Installation</h2>
             <div class="install-methods">
                 <div class="install-card">

--- a/docs/index.html
+++ b/docs/index.html
@@ -65,15 +65,18 @@
                     <p>Built with Rust for exceptional performance, with parallel operations and efficient resource utilization.</p>
                 </div>
             </div>
-        </section>
-
-        <section id="installation">
+        </section>        <section id="installation">
             <h2>📦 Installation</h2>
             <div class="install-methods">
                 <div class="install-card">
                     <h3>From crates.io</h3>
                     <pre><code>cargo install azdocli</code></pre>
                     <p>The easiest way to install. This will install the <code>azdocli</code> binary.</p>
+                </div>
+                <div class="install-card">
+                    <h3>Using Snap (Linux)</h3>
+                    <pre><code>snap install azdocli</code></pre>
+                    <p>Install directly from the Snap Store on Linux systems with automatic updates.</p>
                 </div>
                 <div class="install-card">
                     <h3>From GitHub Releases</h3>

--- a/docs/user-guide.html
+++ b/docs/user-guide.html
@@ -12,12 +12,11 @@
             <h1>📖 User Guide</h1>
             <p class="subtitle">Complete guide to Azure DevOps CLI features and commands</p>
         </div>
-    </header>
-
-    <nav>
+    </header>    <nav>
         <div class="container">
             <ul>
                 <li><a href="index.html">Home</a></li>
+                <li><a href="#installation">Installation</a></li>
                 <li><a href="#authentication">Authentication</a></li>
                 <li><a href="#projects">Projects</a></li>
                 <li><a href="#repositories">Repositories</a></li>
@@ -26,12 +25,42 @@
                 <li><a href="#testing">Testing</a></li>
             </ul>
         </div>
-    </nav>
-
-    <main class="container">
+    </nav><main class="container">
         <section id="getting-started">
             <h2>🚀 Getting Started</h2>
             <p>Azure DevOps CLI (azdocli) provides a powerful command-line interface for interacting with Azure DevOps services. This guide covers all features and commands available in the tool.</p>
+        </section>
+
+        <section id="installation">
+            <h2>📦 Installation</h2>
+            <div class="command-section">
+                <h3>Installation Methods</h3>
+                <p>Choose the installation method that works best for your system:</p>
+                
+                <div class="command-example">
+                    <h4>From crates.io (Recommended)</h4>
+                    <pre><code>cargo install azdocli</code></pre>
+                    <p>This is the easiest way to install azdocli. It requires Rust and Cargo to be installed on your system.</p>
+                </div>
+
+                <div class="command-example">
+                    <h4>Using Snap (Linux)</h4>
+                    <pre><code>snap install azdocli</code></pre>
+                    <p>On Linux systems with Snap support, you can install azdocli directly from the Snap Store. This method provides automatic updates and easy installation.</p>
+                </div>
+
+                <div class="command-example">
+                    <h4>From GitHub Releases</h4>
+                    <p>Download pre-built binaries for your platform:</p>
+                    <ul>
+                        <li><strong>Windows:</strong> <code>windows-x64.zip</code> or <code>windows-arm64.zip</code></li>
+                        <li><strong>macOS:</strong> <code>macos-x64.zip</code> or <code>macos-arm64.zip</code></li>
+                        <li><strong>Linux:</strong> <code>linux-x64.zip</code> or <code>linux-arm64.zip</code></li>
+                    </ul>
+                    <p>Visit the <a href="https://github.com/christianhelle/azdocli/releases">GitHub Releases page</a> to download the latest version.</p>
+                    <p>Extract the binary from the downloaded archive and add it to your system's PATH.</p>
+                </div>
+            </div>
         </section>
 
         <section id="authentication">

--- a/docs/user-guide.html
+++ b/docs/user-guide.html
@@ -12,7 +12,8 @@
             <h1>📖 User Guide</h1>
             <p class="subtitle">Complete guide to Azure DevOps CLI features and commands</p>
         </div>
-    </header>    <nav>
+    </header>
+    <nav>
         <div class="container">
             <ul>
                 <li><a href="index.html">Home</a></li>
@@ -25,7 +26,8 @@
                 <li><a href="#testing">Testing</a></li>
             </ul>
         </div>
-    </nav><main class="container">
+    </nav>
+    <main class="container">
         <section id="getting-started">
             <h2>🚀 Getting Started</h2>
             <p>Azure DevOps CLI (azdocli) provides a powerful command-line interface for interacting with Azure DevOps services. This guide covers all features and commands available in the tool.</p>

--- a/src/README.md
+++ b/src/README.md
@@ -326,6 +326,16 @@ cargo install azdocli
 
 This will install the `azdocli` binary, which you can use immediately.
 
+### Install using Snap (Linux)
+
+On Linux systems with Snap support, you can install azdocli directly from the Snap Store:
+
+```bash
+snap install azdocli
+```
+
+This will install the latest stable version and automatically handle updates.
+
 ### Install from GitHub Releases
 
 You can also download pre-built binaries from the [GitHub Releases page](https://github.com/christianhelle/azdocli/releases):


### PR DESCRIPTION
This pull request introduces a new installation method for `azdocli` using Snap on Linux systems and updates the documentation to reflect this addition. The changes enhance user accessibility by providing an alternative installation method and improving the structure and content of the documentation.

### New Installation Method:
* Added instructions for installing `azdocli` using Snap on Linux systems in `README.md` and `src/README.md`. This method provides automatic updates and simplifies installation for Linux users. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R332-R341) [[2]](diffhunk://#diff-e1d5879ce3e222eb0cdd43051fb8c34c00796467acb091d0b3fa939ee3355cb5R329-R338)

### Documentation Enhancements:
* Updated `docs/index.html` to include a new installation card for Snap under the "Installation" section.
* Improved `docs/user-guide.html` by adding a dedicated "Installation" section with detailed instructions for all installation methods, including Snap. This improves clarity and user experience.
* Added a navigation link to the "Installation" section in `docs/user-guide.html` for easier access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added instructions for installing the CLI tool using Snap on Linux across the README and documentation pages.
  - Updated the user guide with a new "Installation" section detailing all available installation methods, including Snap.
  - Enhanced navigation in the user guide to include the new installation section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->