### PR TITLE
Implement Work Item subcommand to List "My" work items

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,15 @@ azdocli pipelines run --id 42 --project MyProject
 The `boards work-item` commands allow you to manage work items in an Azure DevOps project:
 
 ```sh
+# List work items assigned to me (using default project)
+azdocli boards work-item list
+
+# List work items with filters
+azdocli boards work-item list --state "Active" --work-item-type "Bug" --limit 20
+
+# Or specify a project explicitly
+azdocli boards work-item list --project MyProject
+
 # Show details of a specific work item (using default project)
 azdocli boards work-item show --id 123
 
@@ -302,7 +311,9 @@ azdocli boards work-item delete --id 123 --soft-delete
 **Work Item Features:**
 
 - **Full CRUD operations**: Create, read, update, and delete work items
+- **List my work items**: View work items assigned to you with filtering options
 - **Multiple work item types**: Support for bug, task, user story, feature, and epic
+- **Filtering**: Filter by state, work item type, and limit number of results
 - **Web integration**: Open work items directly in browser with `--web` option
 - **Soft delete**: Option to change state to "Removed" instead of permanent deletion
 - **Field updates**: Update title, description, state, and priority

--- a/docs/index.html
+++ b/docs/index.html
@@ -53,7 +53,7 @@
                 </div>
                 <div class="feature-card">
                     <h3>📋 Board Management</h3>
-                    <p>Comprehensive work item management with full CRUD operations, support for multiple work item types, and web integration.</p>
+                    <p>Comprehensive work item management with full CRUD operations, advanced filtering, list my work items, support for multiple work item types, and web integration.</p>
                 </div>
                 <div class="feature-card">
                     <h3>🔐 Secure Authentication</h3>
@@ -140,7 +140,13 @@ azdocli repos pr create --repo MyRepo --source "feature/my-feature" --title "My 
 
 # Pipeline management
 azdocli pipelines list
-azdocli pipelines runs --id 42</code></pre>
+azdocli pipelines runs --id 42
+
+# Board management - Work Items
+azdocli boards work-item list
+azdocli boards work-item list --state "Active" --work-item-type "Bug"
+azdocli boards work-item show --id 123
+azdocli boards work-item create bug --title "Fix login issue"</code></pre>
                 </div>
             </div>
         </section>

--- a/docs/user-guide.html
+++ b/docs/user-guide.html
@@ -439,7 +439,24 @@ azdocli pipelines run --id 42 --project MyProject</code></pre>
             <div class="command-section">
                 <h3>Work Item Management</h3>
                 <p>The boards work-item commands allow you to manage work items in an Azure DevOps project with full
-                    CRUD operations.</p>
+                    CRUD operations and advanced filtering capabilities.</p>
+
+                <div class="command-example">
+                    <h4>List My Work Items</h4>
+                    <pre><code># List work items assigned to me
+azdocli boards work-item list
+
+# List work items with filters
+azdocli boards work-item list --state "Active" --work-item-type "Bug" --limit 20
+
+# Or specify a project explicitly
+azdocli boards work-item list --project MyProject
+
+# Advanced filtering examples
+azdocli boards work-item list --state "New" --limit 10
+azdocli boards work-item list --work-item-type "User Story" --state "Active"</code></pre>
+                    <p><strong>Features</strong>: View work items assigned to you with filtering by state, work item type, and configurable result limits.</p>
+                </div>
 
                 <div class="command-example">
                     <h4>Show Work Item</h4>
@@ -482,8 +499,10 @@ azdocli boards work-item delete --id 123 --soft-delete</code></pre>
                 <h4>Work Item Features:</h4>
                 <ul>
                     <li><strong>Full CRUD operations</strong>: Create, read, update, and delete work items</li>
+                    <li><strong>List my work items</strong>: View work items assigned to you with advanced filtering options</li>
                     <li><strong>Multiple work item types</strong>: Support for bug, task, user story, feature, and epic
                     </li>
+                    <li><strong>Advanced filtering</strong>: Filter by state, work item type, and limit number of results</li>
                     <li><strong>Web integration</strong>: Open work items directly in browser with --web option</li>
                     <li><strong>Soft delete</strong>: Option to change state to "Removed" instead of permanent deletion
                     </li>
@@ -491,6 +510,7 @@ azdocli boards work-item delete --id 123 --soft-delete</code></pre>
                     <li><strong>Default project support</strong>: Use with default project or specify --project
                         explicitly</li>
                     <li><strong>Error handling</strong>: Clear feedback when work item not found or access denied</li>
+                    <li><strong>WIQL integration</strong>: Uses Azure DevOps Work Item Query Language for efficient data retrieval</li>
                 </ul>
             </div>
         </section>

--- a/src/README.md
+++ b/src/README.md
@@ -273,6 +273,15 @@ azdocli pipelines run --id 42 --project MyProject
 The `boards work-item` commands allow you to manage work items in an Azure DevOps project:
 
 ```sh
+# List work items assigned to me (using default project)
+azdocli boards work-item list
+
+# List work items with filters
+azdocli boards work-item list --state "Active" --work-item-type "Bug" --limit 20
+
+# Or specify a project explicitly
+azdocli boards work-item list --project MyProject
+
 # Show details of a specific work item (using default project)
 azdocli boards work-item show --id 123
 
@@ -299,7 +308,9 @@ azdocli boards work-item delete --id 123 --soft-delete
 **Work Item Features:**
 
 - **Full CRUD operations**: Create, read, update, and delete work items
+- **List my work items**: View work items assigned to you with filtering options
 - **Multiple work item types**: Support for bug, task, user story, feature, and epic
+- **Filtering**: Filter by state, work item type, and limit number of results
 - **Web integration**: Open work items directly in browser with `--web` option
 - **Soft delete**: Option to change state to "Removed" instead of permanent deletion
 - **Field updates**: Update title, description, state, and priority

--- a/src/boards.rs
+++ b/src/boards.rs
@@ -59,6 +59,21 @@ pub enum WorkItemSubCommands {
         #[clap(long)]
         soft_delete: bool,
     },
+    /// List work items assigned to me
+    List {
+        /// Team project name (optional if default project is set)
+        #[clap(short, long)]
+        project: Option<String>,
+        /// Filter by work item state (e.g., 'Active', 'New', 'Resolved')
+        #[clap(long)]
+        state: Option<String>,
+        /// Filter by work item type (e.g., 'Bug', 'Task', 'User Story')
+        #[clap(long)]
+        work_item_type: Option<String>,
+        /// Maximum number of work items to return (default: 50)
+        #[clap(long, default_value = "50")]
+        limit: i32,
+    },
     /// Show details of a work item
     Show {
         /// ID of the work item to show

--- a/src/boards.rs
+++ b/src/boards.rs
@@ -321,6 +321,180 @@ fn display_work_item(work_item: &models::WorkItem) {
     }
 }
 
+fn display_work_items_list(work_items: &[models::WorkItem]) {
+    println!();
+    println!("📋 My Work Items ({} items)", work_items.len());
+    let separator = "=".repeat(80);
+    println!("{}", separator);
+    println!("{:<8} {:<15} {:<20} {:<30}", "ID", "Type", "State", "Title");
+    let dash_separator = "-".repeat(80);
+    println!("{}", dash_separator);
+
+    for work_item in work_items {
+        let id = work_item.id;
+
+        let (work_item_type, state, title) = if let Some(fields) = work_item.fields.as_object() {
+            let wit_type = fields
+                .get("System.WorkItemType")
+                .and_then(|v| v.as_str())
+                .unwrap_or("Unknown");
+
+            let state = fields
+                .get("System.State")
+                .and_then(|v| v.as_str())
+                .unwrap_or("Unknown");
+
+            let title = fields
+                .get("System.Title")
+                .and_then(|v| v.as_str())
+                .unwrap_or("No Title");
+
+            (wit_type, state, title)
+        } else {
+            ("Unknown", "Unknown", "No Title")
+        };
+
+        // Truncate title if too long
+        let truncated_title = if title.len() > 30 {
+            format!("{}...", &title[..27])
+        } else {
+            title.to_string()
+        };
+
+        println!(
+            "{:<8} {:<15} {:<20} {:<30}",
+            id,
+            work_item_type,
+            state,
+            truncated_title
+        );
+    }
+
+    println!();
+    println!("💡 Use 'azdocli boards work-item show --id <ID>' for detailed information");
+    println!("💡 Use 'azdocli boards work-item show --id <ID> --web' to open in browser");
+}
+
+async fn list_my_work_items(
+    project: &str,
+    state_filter: Option<&str>,
+    work_item_type_filter: Option<&str>,
+    limit: i32,
+) -> Result<()> {
+    match get_credentials() {
+        Ok(creds) => {
+            let client = create_client()?;
+
+            println!(
+                "📋 Listing work items assigned to you in project: {}",
+                project
+            );
+
+            if let Some(state) = state_filter {
+                println!("🔍 Filtering by state: {}", state);
+            }
+
+            if let Some(wit_type) = work_item_type_filter {
+                println!("🔍 Filtering by type: {}", wit_type);
+            }
+
+            println!("📊 Limit: {} items", limit);
+
+            let wiql_query = build_wiql_query(project, state_filter, work_item_type_filter);
+
+            // Create WIQL request body
+            let wiql_request = models::Wiql {
+                query: Some(wiql_query),
+            };            // Execute the WIQL query
+            match client
+                .wiql_client()
+                .query_by_wiql(creds.organization.clone(), wiql_request, project.to_string(), "".to_string())
+                .await
+            {
+                Ok(query_result) => {
+                    let work_items = query_result.work_items;
+                    if work_items.is_empty() {
+                        display_empty_work_items_table();
+                        return Ok(());
+                    }
+
+                    // Take only the requested number of items
+                    let limited_items: Vec<_> = work_items.into_iter().take(limit as usize).collect();
+                    
+                    // Get detailed work item information by calling get_work_item for each ID
+                    let mut detailed_work_items = Vec::new();
+                    for work_item_ref in &limited_items {
+                        if let Some(id) = work_item_ref.id {
+                            match client
+                                .work_items_client()
+                                .get_work_item(creds.organization.clone(), id, project)
+                                .await
+                            {
+                                Ok(detailed_item) => detailed_work_items.push(detailed_item),
+                                Err(e) => eprintln!("❌ Failed to get details for work item {}: {}", id, e),
+                            }
+                        }
+                    }
+
+                    if !detailed_work_items.is_empty() {
+                        display_work_items_list(&detailed_work_items);
+                    } else {
+                        display_empty_work_items_table();
+                    }
+                }
+                Err(e) => {
+                    eprintln!("❌ Failed to execute WIQL query: {}", e);
+                    display_empty_work_items_table();
+                }
+            }
+
+            Ok(())
+        }
+        Err(e) => {
+            eprintln!("Unable to list work items");
+            Err(e)
+        }
+    }
+}
+
+fn build_wiql_query(
+    project: &str,
+    state_filter: Option<&str>,
+    work_item_type_filter: Option<&str>,
+) -> String {
+    let mut wiql_query = format!(
+        "SELECT [System.Id], [System.Title], [System.State], [System.WorkItemType], [System.AssignedTo], [System.CreatedDate], [Microsoft.VSTS.Common.Priority] FROM WorkItems WHERE [System.TeamProject] = '{}' AND [System.AssignedTo] = @Me",
+        project
+    );
+
+    // Add state filter if provided
+    if let Some(state) = state_filter {
+        wiql_query.push_str(&format!(" AND [System.State] = '{}'", state));
+    }
+
+    // Add work item type filter if provided
+    if let Some(wit_type) = work_item_type_filter {
+        wiql_query.push_str(&format!(" AND [System.WorkItemType] = '{}'", wit_type));
+    }
+
+    wiql_query.push_str(" ORDER BY [System.CreatedDate] DESC");
+    wiql_query
+}
+
+fn display_empty_work_items_table() {
+    println!();
+    println!("📋 My Work Items (0 items)");
+    let separator = "=".repeat(80);
+    println!("{}", separator);
+    println!("{:<8} {:<15} {:<20} {:<30}", "ID", "Type", "State", "Title");
+    let dash_separator = "-".repeat(80);
+    println!("{}", dash_separator);
+    println!("No work items found assigned to you.");
+    println!();
+    println!("💡 Use 'azdocli boards work-item show --id <ID>' for detailed information");
+    println!("💡 Use 'azdocli boards work-item show --id <ID> --web' to open in browser");
+}
+
 pub async fn handle_command(subcommand: &BoardsSubCommands) -> Result<()> {
     let _credentials = get_credentials()?;
     match subcommand {
@@ -381,6 +555,31 @@ async fn handle_work_item_command(subcommand: &WorkItemSubCommands) -> Result<()
                 }
                 Err(e) => {
                     eprintln!("❌ Failed to delete work item: {}", e);
+                    return Err(e);
+                }
+            }
+        }
+        WorkItemSubCommands::List {
+            project,
+            state,
+            work_item_type,
+            limit,
+        } => {
+            let project_name = get_project_or_default(project.as_deref())?;
+
+            match list_my_work_items(
+                &project_name,
+                state.as_deref(),
+                work_item_type.as_deref(),
+                *limit,
+            )
+            .await
+            {
+                Ok(_) => {
+                    println!("{}", "✅ Work items listed successfully!".green());
+                }
+                Err(e) => {
+                    eprintln!("❌ Failed to list work items: {}", e);
                     return Err(e);
                 }
             }


### PR DESCRIPTION
This pull request introduces a new feature to the Azure DevOps CLI (`azdocli`) for listing work items assigned to the current user, along with advanced filtering options. It includes updates to the documentation, CLI commands, and backend implementation to support this functionality.

### Documentation Updates:
* `README.md` and `src/README.md`: Added examples for the new `azdocli boards work-item list` command, showcasing filtering by state, work item type, and limiting results. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R279-R287) [[2]](diffhunk://#diff-e1d5879ce3e222eb0cdd43051fb8c34c00796467acb091d0b3fa939ee3355cb5R276-R284)
* [`docs/index.html`](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL143-R149): Expanded the "Board Management" section to include examples of listing work items and creating new ones.
* [`docs/user-guide.html`](diffhunk://#diff-cdfb783839b689d2404f69c12eb560bbb55ecc04b2f46d4df0cb8feef783a7b6L442-R459): Enhanced the "Work Item Management" section with detailed examples and descriptions of the new listing and filtering capabilities. [[1]](diffhunk://#diff-cdfb783839b689d2404f69c12eb560bbb55ecc04b2f46d4df0cb8feef783a7b6L442-R459) [[2]](diffhunk://#diff-cdfb783839b689d2404f69c12eb560bbb55ecc04b2f46d4df0cb8feef783a7b6R502-R513)

### CLI Command Enhancements:
* [`src/boards.rs`](diffhunk://#diff-773c082c409c154a49b33cb116e1c2bd654ca6d26afa49d2f1684ed1b10e404eR62-R76): Added a new subcommand `List` under `WorkItemSubCommands` to list work items with optional filters for project, state, work item type, and result limit.

### Backend Implementation:
* [`src/boards.rs`](diffhunk://#diff-773c082c409c154a49b33cb116e1c2bd654ca6d26afa49d2f1684ed1b10e404eR324-R497): Implemented `list_my_work_items` function to query Azure DevOps using WIQL (Work Item Query Language) for retrieving work items assigned to the current user, with support for filtering and detailed display formatting.
* [`src/boards.rs`](diffhunk://#diff-773c082c409c154a49b33cb116e1c2bd654ca6d26afa49d2f1684ed1b10e404eR562-R586): Updated `handle_work_item_command` to handle the new `List` subcommand and provide appropriate feedback on success or failure.