### PR TITLE
Add create, delete, and show subcommands to projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ CLI tool for interacting with Azure DevOps.
 
 - **Repository Management**: List, create, delete, clone, view, and manage pull requests in repositories
 - **Pipeline Management**: Manage Azure DevOps pipelines
-- **Project Management**: List and view Azure DevOps projects in your organization (azdocli projects list)
+- **Project Management**: Create, delete, list, and show Azure DevOps team projects in your organization
 - **Board Management**: Manage Azure DevOps boards
 - **Authentication**: Secure login using Personal Access Tokens (PAT)
 - **Default Project**: Set a default project to avoid specifying --project for every command
@@ -458,6 +458,9 @@ azdocli pipelines show --id 42 --build-id 123 # Show build details
 
 # Projects management
 azdocli projects list                        # List all projects in the organization
+azdocli projects show --project MyProject    # Show a project by name or ID
+azdocli projects create --name MyProject     # Create a new team project
+azdocli projects delete --id <project-id>    # Delete a team project
 ```
 
 For detailed examples and features, see the respective sections below.

--- a/docs/index.html
+++ b/docs/index.html
@@ -100,13 +100,13 @@
             </p>
           </div>
           <div class="feature-card">
-            <h3>📂 Projects</h3>
-            <p>
-              List and view Azure DevOps projects within an organization using
-              <code>azdocli projects list</code>. This organization-scoped
-              command does not require a project argument.
-            </p>
-          </div>
+              <h3>📂 Projects</h3>
+              <p>
+              Create, delete, list, and show Azure DevOps team projects within
+              an organization using <code>azdocli projects</code> subcommands.
+              These commands are organization-scoped and use your stored login.
+              </p>
+            </div>
           <div class="feature-card">
             <h3>🚀 Performance</h3>
             <p>

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -13,7 +13,7 @@ azdocli/
 │   ├── auth.rs            # Credential storage/retrieval, login/logout
 │   ├── config.rs          # Config directory (~/.azdocli/) management
 │   ├── project.rs         # Default project get/set
-│   ├── projects.rs        # "projects list" command (core API)
+│   ├── projects.rs        # Team project management commands (core API)
 │   ├── repos.rs           # Repository CRUD, bulk clone
 │   ├── pr.rs              # Pull request operations
 │   ├── pipelines.rs       # Pipeline & build management
@@ -217,7 +217,7 @@ azdocli artifacts list  # Test against a real organization
 ### Conventions to Follow
 
 - **Project argument**: Commands scoped to a project should accept `--project` / `-p` and fall back to `get_project_or_default()`.
-- **Organization-scoped commands**: Commands that only need the organization (like `projects list`) can skip the project argument entirely and read it from `get_credentials().organization`.
+- **Organization-scoped commands**: Commands that only need the organization (like `projects list/create/delete/show`) can skip the project argument entirely and read it from `get_credentials().organization`.
 - **Error messages**: Use `eprintln!("...")` for errors. Prefix with a relevant emoji if appropriate.
 - **Output format**: Use `println!` with fixed-width columns for tabular data. Truncate long fields.
 - **Confirmation prompts**: Destructive operations (delete, etc.) should use `dialoguer::Confirm` and support a `--yes` / `-y` flag to skip.

--- a/docs/user-guide.html
+++ b/docs/user-guide.html
@@ -242,23 +242,36 @@
             <pre><code>azdocli project</code></pre>
           </div>
 
-          <h3>Listing Projects</h3>
+          <h3>Project Management Commands</h3>
           <p>
-            List all Azure DevOps projects in your organization using the
-            <code>projects list</code> command. This organization-scoped command
-            authenticates with your stored credentials and displays a formatted
-            table with Name, ID, State, Visibility, and a short Description.
-            Example:
+            Manage team projects in your Azure DevOps organization with the
+            <code>projects</code> command group.
           </p>
 
           <div class="command-example">
+            <h4>List projects</h4>
             <pre><code>azdocli projects list</code></pre>
           </div>
 
+          <div class="command-example">
+            <h4>Show a project</h4>
+            <pre><code>azdocli projects show --project MyProject</code></pre>
+          </div>
+
+          <div class="command-example">
+            <h4>Create a project</h4>
+            <pre><code>azdocli projects create --name MyProject --description "Team workspace" --process Agile --source-control git --visibility private</code></pre>
+          </div>
+
+          <div class="command-example">
+            <h4>Delete a project</h4>
+            <pre><code>azdocli projects delete --id 00000000-0000-0000-0000-000000000000 --yes</code></pre>
+          </div>
+
           <p>
-            Note: <code>azdocli projects list</code> is organization-scoped and
-            does not require a project argument. Make sure you have
-            authenticated with <code>azdocli login</code> before running it.
+            Note: <code>azdocli projects</code> commands are organization-scoped
+            and rely on your stored credentials from
+            <code>azdocli login</code>.
           </p>
 
           <h4>Features:</h4>

--- a/src/projects.rs
+++ b/src/projects.rs
@@ -1,12 +1,88 @@
 use crate::auth::get_credentials;
-use anyhow::Result;
-use azure_devops_rust_api::core::ClientBuilder;
-use clap::Subcommand;
+use anyhow::{anyhow, Result};
+use azure_devops_rust_api::core::{models, ClientBuilder};
+use clap::{Subcommand, ValueEnum};
+use dialoguer::Confirm;
+use serde_json::json;
+use std::process::Command;
+use tokio::time::{sleep, Duration};
+
+const CREATE_OPEN_WAIT_RETRIES: usize = 30;
+const CREATE_OPEN_WAIT_INTERVAL: Duration = Duration::from_secs(2);
 
 #[derive(Subcommand, Clone)]
 pub enum ProjectsSubCommands {
     /// List all projects in the organization
     List,
+    /// Create a team project
+    Create {
+        /// Name of the new project
+        #[clap(long)]
+        name: String,
+        /// Description for the new project
+        #[clap(short, long)]
+        description: Option<String>,
+        /// Process to use (name or ID)
+        #[clap(short, long)]
+        process: Option<String>,
+        /// Source control type of the initial repository
+        #[clap(short = 's', long, value_enum, default_value_t = ProjectSourceControl::Git)]
+        source_control: ProjectSourceControl,
+        /// Project visibility
+        #[clap(long, value_enum, default_value_t = ProjectVisibility::Private)]
+        visibility: ProjectVisibility,
+        /// Open the team project in the default web browser
+        #[clap(long)]
+        open: bool,
+    },
+    /// Delete team project
+    Delete {
+        /// The id of the project to delete
+        #[clap(long)]
+        id: String,
+        /// Do not prompt for confirmation
+        #[clap(short = 'y', long)]
+        yes: bool,
+    },
+    /// Show team project
+    Show {
+        /// Name or ID of the project
+        #[clap(short = 'p', long)]
+        project: String,
+        /// Open the team project in the default web browser
+        #[clap(long)]
+        open: bool,
+    },
+}
+
+#[derive(Clone, Debug, ValueEnum)]
+pub enum ProjectSourceControl {
+    Git,
+    Tfvc,
+}
+
+impl ProjectSourceControl {
+    fn as_api_value(&self) -> &'static str {
+        match self {
+            ProjectSourceControl::Git => "Git",
+            ProjectSourceControl::Tfvc => "Tfvc",
+        }
+    }
+}
+
+#[derive(Clone, Debug, ValueEnum)]
+pub enum ProjectVisibility {
+    Private,
+    Public,
+}
+
+impl ProjectVisibility {
+    fn as_api_value(&self) -> models::team_project_reference::Visibility {
+        match self {
+            ProjectVisibility::Private => models::team_project_reference::Visibility::Private,
+            ProjectVisibility::Public => models::team_project_reference::Visibility::Public,
+        }
+    }
 }
 
 pub async fn handle_command(subcommand: &ProjectsSubCommands) -> Result<()> {
@@ -14,7 +90,281 @@ pub async fn handle_command(subcommand: &ProjectsSubCommands) -> Result<()> {
         ProjectsSubCommands::List => {
             list_projects().await?;
         }
+        ProjectsSubCommands::Create {
+            name,
+            description,
+            process,
+            source_control,
+            visibility,
+            open,
+        } => {
+            let operation = create_project(
+                name,
+                description.as_deref(),
+                process.as_deref(),
+                source_control,
+                visibility,
+            )
+            .await?;
+
+            display_operation_reference("Project creation queued", &operation);
+
+            if *open {
+                let project = wait_for_project_to_be_ready(name).await?;
+                let organization = get_credentials()?.organization;
+                open_project_in_browser(&organization, &project.team_project_reference.name)?;
+            }
+        }
+        ProjectsSubCommands::Delete { id, yes } => {
+            let project = get_project(id).await?;
+            let project_id = project
+                .team_project_reference
+                .id
+                .clone()
+                .unwrap_or(id.clone());
+            let project_name = project.team_project_reference.name.clone();
+
+            if !*yes
+                && !Confirm::new()
+                    .with_prompt(format!(
+                        "Are you sure you want to delete project '{project_name}' ({project_id})?"
+                    ))
+                    .default(false)
+                    .interact()?
+            {
+                println!("Delete operation cancelled.");
+                return Ok(());
+            }
+
+            let operation = delete_project(&project_id).await?;
+            display_operation_reference("Project delete queued", &operation);
+        }
+        ProjectsSubCommands::Show { project, open } => {
+            let team_project = get_project(project).await?;
+            display_project_details(&team_project);
+
+            if *open {
+                let organization = get_credentials()?.organization;
+                open_project_in_browser(&organization, &team_project.team_project_reference.name)?;
+            }
+        }
     }
+    Ok(())
+}
+
+async fn create_project(
+    name: &str,
+    description: Option<&str>,
+    process: Option<&str>,
+    source_control: &ProjectSourceControl,
+    visibility: &ProjectVisibility,
+) -> Result<models::OperationReference> {
+    let creds = get_credentials()?;
+    let credential = azure_devops_rust_api::Credential::Pat(creds.pat);
+    let client = ClientBuilder::new(credential).build();
+    let process_template_id =
+        resolve_process_template_id(&client, &creds.organization, process).await?;
+
+    let mut project_reference =
+        models::TeamProjectReference::new(name.to_string(), visibility.as_api_value());
+    project_reference.description = description.map(str::to_owned);
+
+    let mut team_project = models::TeamProject::new(project_reference);
+    team_project.capabilities = Some(json!({
+        "versioncontrol": {
+            "sourceControlType": source_control.as_api_value(),
+        },
+        "processTemplate": {
+            "templateTypeId": process_template_id,
+        }
+    }));
+
+    Ok(client
+        .projects_client()
+        .create(&creds.organization, team_project)
+        .await?)
+}
+
+async fn delete_project(project_id: &str) -> Result<models::OperationReference> {
+    let creds = get_credentials()?;
+    let credential = azure_devops_rust_api::Credential::Pat(creds.pat);
+    let client = ClientBuilder::new(credential).build();
+
+    Ok(client
+        .projects_client()
+        .delete(&creds.organization, project_id)
+        .await?)
+}
+
+async fn get_project(project: &str) -> Result<models::TeamProject> {
+    let creds = get_credentials()?;
+    let credential = azure_devops_rust_api::Credential::Pat(creds.pat);
+    let client = ClientBuilder::new(credential).build();
+
+    Ok(client
+        .projects_client()
+        .get(&creds.organization, project)
+        .await?)
+}
+
+async fn resolve_process_template_id(
+    client: &azure_devops_rust_api::core::Client,
+    organization: &str,
+    process: Option<&str>,
+) -> Result<String> {
+    let processes = client.processes_client().list(organization).await?.value;
+
+    if processes.is_empty() {
+        return Err(anyhow!(
+            "No process templates found in organization '{}'",
+            organization
+        ));
+    }
+
+    if let Some(process_name_or_id) = process {
+        if let Some(process_id) = processes
+            .iter()
+            .find(|p| p.id.as_deref() == Some(process_name_or_id))
+            .and_then(|p| p.id.clone())
+        {
+            return Ok(process_id);
+        }
+
+        if let Some(process_id) = processes
+            .iter()
+            .find(|p| {
+                p.process_reference
+                    .name
+                    .as_deref()
+                    .is_some_and(|name| name.eq_ignore_ascii_case(process_name_or_id))
+            })
+            .and_then(|p| p.id.clone())
+        {
+            return Ok(process_id);
+        }
+
+        let available_processes = processes
+            .iter()
+            .filter_map(|p| p.process_reference.name.clone())
+            .collect::<Vec<_>>();
+
+        let available = if available_processes.is_empty() {
+            "<none>".to_string()
+        } else {
+            available_processes.join(", ")
+        };
+
+        return Err(anyhow!(
+            "Process '{}' not found. Available processes: {}",
+            process_name_or_id,
+            available
+        ));
+    }
+
+    if let Some(default_process_id) = processes
+        .iter()
+        .find(|p| p.is_default == Some(true))
+        .and_then(|p| p.id.clone())
+    {
+        return Ok(default_process_id);
+    }
+
+    processes
+        .iter()
+        .find_map(|p| p.id.clone())
+        .ok_or_else(|| anyhow!("No valid process template IDs found"))
+}
+
+async fn wait_for_project_to_be_ready(project: &str) -> Result<models::TeamProject> {
+    let mut last_error = None;
+
+    for _ in 0..CREATE_OPEN_WAIT_RETRIES {
+        match get_project(project).await {
+            Ok(team_project) => {
+                let state = team_project.team_project_reference.state.clone();
+                if matches!(
+                    state,
+                    Some(models::team_project_reference::State::WellFormed)
+                ) {
+                    return Ok(team_project);
+                }
+            }
+            Err(error) => {
+                last_error = Some(error);
+            }
+        }
+
+        sleep(CREATE_OPEN_WAIT_INTERVAL).await;
+    }
+
+    if let Some(error) = last_error {
+        return Err(anyhow!(
+            "Project '{}' was created, but is not ready yet: {}",
+            project,
+            error
+        ));
+    }
+
+    Err(anyhow!(
+        "Project '{}' was created, but is not ready yet. Try again with 'azdocli projects show --project {}'",
+        project,
+        project
+    ))
+}
+
+fn display_project_details(project: &models::TeamProject) {
+    let project_ref = &project.team_project_reference;
+
+    println!("📁 Team Project Details");
+    println!("=======================");
+    println!("Name: {}", project_ref.name);
+    println!("ID: {}", project_ref.id.as_deref().unwrap_or("-"));
+    println!(
+        "State: {}",
+        project_ref
+            .state
+            .as_ref()
+            .map(|state| format!("{state:?}"))
+            .unwrap_or_else(|| "-".to_string())
+    );
+    println!("Visibility: {:?}", project_ref.visibility);
+    if let Some(description) = &project_ref.description {
+        println!("Description: {description}");
+    }
+    if let Some(url) = &project_ref.url {
+        println!("URL: {url}");
+    }
+}
+
+fn display_operation_reference(label: &str, operation: &models::OperationReference) {
+    println!("✅ {label}");
+    if let Some(status) = &operation.status {
+        println!("Status: {status:?}");
+    }
+    if let Some(id) = &operation.id {
+        println!("Operation ID: {id}");
+    }
+}
+
+fn open_project_in_browser(organization: &str, project_name: &str) -> Result<()> {
+    let project_url = format!("https://dev.azure.com/{organization}/{project_name}");
+
+    #[cfg(target_os = "windows")]
+    {
+        Command::new("explorer").arg(&project_url).spawn()?;
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        Command::new("open").arg(&project_url).spawn()?;
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        Command::new("xdg-open").arg(&project_url).spawn()?;
+    }
+
+    println!("Opening project in browser: {project_url}");
     Ok(())
 }
 

--- a/test/test_commands.ps1
+++ b/test/test_commands.ps1
@@ -28,5 +28,20 @@ Write-Host "`nTesting repos list help..." -ForegroundColor Yellow
 Write-Host "`nTesting repos clone help..." -ForegroundColor Yellow
 & $exe repos clone --help
 
+Write-Host "`nTesting projects help..." -ForegroundColor Yellow
+& $exe projects --help
+
+Write-Host "`nTesting projects list help..." -ForegroundColor Yellow
+& $exe projects list --help
+
+Write-Host "`nTesting projects show help..." -ForegroundColor Yellow
+& $exe projects show --help
+
+Write-Host "`nTesting projects create help..." -ForegroundColor Yellow
+& $exe projects create --help
+
+Write-Host "`nTesting projects delete help..." -ForegroundColor Yellow
+& $exe projects delete --help
+
 Write-Host "`nAll command-line interface tests completed successfully!" -ForegroundColor Green
 Write-Host "Note: Actual functionality requires Azure DevOps authentication." -ForegroundColor Cyan


### PR DESCRIPTION
## Why

The `azdocli projects` command previously only supported listing projects. This PR extends it to support full team project lifecycle management—aligned to the Azure CLI `az devops project` command surface—so users can create, view, and delete projects directly from the CLI.

## What Changed

**Core implementation in `src/projects.rs`:**
- Added `Create`, `Delete`, and `Show` variants to `ProjectsSubCommands` enum
- Implemented `ProjectSourceControl` and `ProjectVisibility` `ValueEnum` types for safe flag parsing
- Created async handlers for each operation:
  - `create_project`: builds a TeamProject with name, description, process template ID (resolved from name), source control, and visibility
  - `delete_project`: queues a project deletion with confirmation prompt and `--yes` bypass
  - `get_project`: retrieves a project by name or ID
  - `show_project`: displays formatted project details
  - `resolve_process_template_id`: resolves process name or ID to template ID with fallback to default process
  - `wait_for_project_to_be_ready`: polls for project state after create (with 30-retry, 2-second interval) before opening in browser
  - `open_project_in_browser`: cross-platform browser opener using OS-native commands

**Command shape (core parity with Azure CLI):**
```
azdocli projects create --name <name> [--description] [--process] [--source-control git|tfvc] [--visibility private|public] [--open]
azdocli projects delete --id <project-id> [--yes]
azdocli projects show --project <name-or-id> [--open]
```

**Documentation updates:**
- `README.md`: added new usage examples for create, delete, show
- `docs/index.html`: updated feature card to reflect full project management capability
- `docs/user-guide.html`: expanded Projects section with create, delete, show examples
- `docs/project-structure.md`: clarified module role (not just `list` anymore)
- `test/test_commands.ps1`: added smoke tests for all new subcommand help surfaces

## Design Notes

- **Process resolution:** User can pass process name (e.g., "Agile") or ID; we resolve to template ID server-side. Falls back to org default if not specified.
- **Async operations:** `create` and `delete` queue async operations; no polling of operation status yet (safe because queuing confirms intent). The `create` command with `--open` will poll for project readiness.
- **Confirmation UX:** `delete` prompts by default; `--yes` skips confirmation for CI/CD scenarios. Prompt shows resolved project name and ID for confidence.
- **Browser open:** Reused cross-platform pattern from `boards.rs`/`wiki.rs` for consistency.
- **Organization scope:** All commands use stored organization from credentials; no `--org` override (keeps azdocli's existing auth model simple).

## Testing

- ✅ `cargo build` succeeds
- ✅ `cargo test` passes (unit tests only; integration tests require Azure DevOps credentials)
- ✅ `cargo clippy` reports no warnings
- ✅ `cargo fmt --check` passes
- ✅ All help surfaces render correctly (projects, projects create/delete/show)
- ✅ No uncommitted changes; branch is clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded project management capabilities: create new team projects with configurable process templates and visibility settings, delete projects, show project details, and list projects. Commands are organization-scoped and use stored credentials. Create and show operations can automatically open projects in your browser.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/christianhelle/azdocli/pull/110?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->