### PR TITLE
Add user management commands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ dirs = "6.0"
 dialoguer = "0.12"
 colored = "3.0"
 azure_devops_rust_api = { version = "0.36.0", features = ["git", "pipelines", "wit", "core", "wiki", "search", "member_entitlement_management"], default-features = false }
+reqwest = { version = "0.12", features = ["json"] }
 chrono = { version = "0.4", features = ["serde"] }
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ anyhow = "1.0"
 dirs = "6.0"
 dialoguer = "0.12"
 colored = "3.0"
-azure_devops_rust_api = { version = "0.36.0", features = ["git", "pipelines", "wit", "core", "wiki", "search"], default-features = false }
+azure_devops_rust_api = { version = "0.36.0", features = ["git", "pipelines", "wit", "core", "wiki", "search", "member_entitlement_management"], default-features = false }
 chrono = { version = "0.4", features = ["serde"] }
 
 [build-dependencies]

--- a/src/README.md
+++ b/src/README.md
@@ -7,6 +7,7 @@ CLI tool for interacting with Azure DevOps.
 - **Repository Management**: List, create, delete, clone, view, and manage pull requests in repositories
 - **Pipeline Management**: Manage Azure DevOps pipelines
 - **Board Management**: Manage Azure DevOps boards
+- **User Management**: Add, list, show, remove, and update organization users
 - **Authentication**: Secure login using Personal Access Tokens (PAT)
 - **Default Project**: Set a default project to avoid specifying --project for every command
 
@@ -266,6 +267,37 @@ azdocli pipelines run --id 42 --project MyProject
 - **Live updates**: See details of the running build in real-time
 - **Error handling**: Clear feedback when pipeline cannot be started
 
+### User Management Features
+
+The `user` commands allow you to manage users and licenses in your Azure DevOps organization:
+
+```sh
+# Add a user with a license
+azdocli user add --email user@contoso.com --license express
+
+# List users (excluding users added via AAD groups)
+azdocli user list
+
+# Show user details by ID or email
+azdocli user show --id 00000000-0000-0000-0000-000000000000
+azdocli user show --email user@contoso.com
+
+# Remove a user by ID or email
+azdocli user remove --id 00000000-0000-0000-0000-000000000000
+azdocli user remove --email user@contoso.com
+
+# Update a user's license type
+azdocli user update --email user@contoso.com --license stakeholder
+```
+
+**User Features:**
+
+- **Organization-wide management**: Manage user access at the organization level
+- **Flexible user targeting**: Use either user ID or email for show, remove, and update
+- **License updates**: Set raw Azure DevOps account license types (`none`, `earlyAdopter`, `express`, `professional`, `advanced`, `stakeholder`)
+- **AAD-group filtering**: User list excludes accounts whose entitlement is inherited from AAD group rules
+- **Error handling**: Clear guidance for missing users and ambiguous email matches
+
 ### Board Management Features
 
 #### Work Item Management
@@ -334,6 +366,7 @@ SUBCOMMANDS:
     logout       Logout from Azure DevOps
     pipelines    Manage Azure DevOps pipelines
     repos        Manage Azure DevOps repos
+    user         Manage users
 ```
 
 ## Installation
@@ -451,6 +484,11 @@ azdocli repos pr create --repo MyRepo --source "feature/my-feature" --title "My 
 azdocli pipelines list                       # List all pipelines
 azdocli pipelines runs --id 42               # Show pipeline runs
 azdocli pipelines show --id 42 --build-id 123 # Show build details
+
+# User management
+azdocli user list                            # List organization users
+azdocli user show --email user@contoso.com   # Show user details
+azdocli user update --email user@contoso.com --license advanced # Update a user's license
 ```
 
 For detailed examples and features, see the respective sections below.

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod pr;
 mod project;
 mod projects;
 mod repos;
+mod user;
 mod wiki;
 
 #[derive(Parser)]
@@ -50,6 +51,11 @@ enum Commands {
         #[clap(subcommand)]
         subcommand: projects::ProjectsSubCommands,
     },
+    /// Manage users
+    User {
+        #[clap(subcommand)]
+        subcommand: user::UserSubCommands,
+    },
     /// Manage Azure DevOps wikis
     Wiki {
         #[clap(subcommand)]
@@ -88,6 +94,9 @@ async fn main() -> anyhow::Result<()> {
         }
         Some(Commands::Projects { subcommand }) => {
             projects::handle_command(subcommand).await?;
+        }
+        Some(Commands::User { subcommand }) => {
+            user::handle_command(subcommand).await?;
         }
         Some(Commands::Wiki { subcommand }) => {
             wiki::handle_command(subcommand).await?;

--- a/src/user.rs
+++ b/src/user.rs
@@ -1,0 +1,460 @@
+use crate::auth::get_credentials;
+use anyhow::{anyhow, Result};
+use azure_devops_rust_api::member_entitlement_management::{self, models, ClientBuilder};
+use clap::{Subcommand, ValueEnum};
+use colored::Colorize;
+use reqwest::header::CONTENT_TYPE;
+use serde_json::json;
+
+#[derive(Subcommand, Clone)]
+pub enum UserSubCommands {
+    /// Add user.
+    Add {
+        /// Email (principal name) of the user to add
+        #[clap(long)]
+        email: String,
+        /// License type for the user
+        #[clap(long, value_enum)]
+        license: UserLicenseType,
+    },
+    /// List users in an organization [except for users which are added via AAD groups].
+    List,
+    /// Remove user from an organization.
+    Remove {
+        /// User ID
+        #[clap(long, conflicts_with = "email", required_unless_present = "email")]
+        id: Option<String>,
+        /// User email (principal name)
+        #[clap(long, conflicts_with = "id", required_unless_present = "id")]
+        email: Option<String>,
+    },
+    /// Show user details.
+    Show {
+        /// User ID
+        #[clap(long, conflicts_with = "email", required_unless_present = "email")]
+        id: Option<String>,
+        /// User email (principal name)
+        #[clap(long, conflicts_with = "id", required_unless_present = "id")]
+        email: Option<String>,
+    },
+    /// Update license type for a user.
+    Update {
+        /// User ID
+        #[clap(long, conflicts_with = "email", required_unless_present = "email")]
+        id: Option<String>,
+        /// User email (principal name)
+        #[clap(long, conflicts_with = "id", required_unless_present = "id")]
+        email: Option<String>,
+        /// New license type
+        #[clap(long, value_enum)]
+        license: UserLicenseType,
+    },
+}
+
+#[derive(Copy, Clone, Debug, ValueEnum)]
+pub enum UserLicenseType {
+    #[value(name = "none")]
+    None,
+    #[value(name = "earlyAdopter")]
+    EarlyAdopter,
+    #[value(name = "express")]
+    Express,
+    #[value(name = "professional")]
+    Professional,
+    #[value(name = "advanced")]
+    Advanced,
+    #[value(name = "stakeholder")]
+    Stakeholder,
+}
+
+impl UserLicenseType {
+    fn as_api_value(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::EarlyAdopter => "earlyAdopter",
+            Self::Express => "express",
+            Self::Professional => "professional",
+            Self::Advanced => "advanced",
+            Self::Stakeholder => "stakeholder",
+        }
+    }
+
+    fn as_account_license_type(self) -> models::access_level::AccountLicenseType {
+        match self {
+            Self::None => models::access_level::AccountLicenseType::None,
+            Self::EarlyAdopter => models::access_level::AccountLicenseType::EarlyAdopter,
+            Self::Express => models::access_level::AccountLicenseType::Express,
+            Self::Professional => models::access_level::AccountLicenseType::Professional,
+            Self::Advanced => models::access_level::AccountLicenseType::Advanced,
+            Self::Stakeholder => models::access_level::AccountLicenseType::Stakeholder,
+        }
+    }
+}
+
+impl std::fmt::Display for UserLicenseType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_api_value())
+    }
+}
+
+pub async fn handle_command(subcommand: &UserSubCommands) -> Result<()> {
+    let creds = get_credentials()?;
+    let client = create_client(creds.pat.clone());
+
+    match subcommand {
+        UserSubCommands::Add { email, license } => {
+            let created = add_user(&client, &creds.organization, email, *license).await?;
+            println!("{}", "✅ User added successfully!".green());
+            println!("ID: {}", user_id(&created).unwrap_or("-"));
+            println!("Email: {}", user_email(&created).unwrap_or("-"));
+            println!(
+                "Display name: {}",
+                user_display_name(&created).unwrap_or("-")
+            );
+            println!("License: {}", user_license(&created));
+        }
+        UserSubCommands::List => {
+            let users = search_user_entitlements(&client, &creds.organization, None).await?;
+            display_users(&users);
+        }
+        UserSubCommands::Remove { id, email } => {
+            let resolved_id = resolve_user_id(&client, &creds.organization, id, email).await?;
+            client
+                .user_entitlements_client()
+                .delete(creds.organization.clone(), resolved_id.clone())
+                .await?;
+
+            println!("{}", "✅ User removed successfully!".green());
+            println!("Removed user ID: {resolved_id}");
+        }
+        UserSubCommands::Show { id, email } => {
+            let resolved_id = resolve_user_id(&client, &creds.organization, id, email).await?;
+            let user = client
+                .user_entitlements_client()
+                .get(creds.organization.clone(), resolved_id)
+                .await?;
+            display_user_details(&user);
+        }
+        UserSubCommands::Update { id, email, license } => {
+            let resolved_id = resolve_user_id(&client, &creds.organization, id, email).await?;
+            update_user_license(&creds.organization, &creds.pat, &resolved_id, *license).await?;
+            let user = client
+                .user_entitlements_client()
+                .get(creds.organization.clone(), resolved_id)
+                .await?;
+
+            println!("{}", "✅ User license updated successfully!".green());
+            println!("Email: {}", user_email(&user).unwrap_or("-"));
+            println!("License: {}", user_license(&user));
+        }
+    }
+
+    Ok(())
+}
+
+fn create_client(pat: String) -> member_entitlement_management::Client {
+    let credential = azure_devops_rust_api::Credential::Pat(pat);
+    ClientBuilder::new(credential).build()
+}
+
+async fn add_user(
+    client: &member_entitlement_management::Client,
+    organization: &str,
+    email: &str,
+    license: UserLicenseType,
+) -> Result<models::UserEntitlement> {
+    let mut access_level = models::AccessLevel::new();
+    access_level.account_license_type = Some(license.as_account_license_type());
+    access_level.licensing_source = Some(models::access_level::LicensingSource::Account);
+    access_level.msdn_license_type = Some(models::access_level::MsdnLicenseType::None);
+    access_level.license_display_name = Some(license.to_string());
+
+    let mut user = models::GraphUser::new();
+    user.aad_graph_member.graph_member.mail_address = Some(email.to_string());
+    user.aad_graph_member.graph_member.principal_name = Some(email.to_string());
+    user.aad_graph_member
+        .graph_member
+        .graph_subject
+        .subject_kind = Some("user".to_string());
+
+    let mut entitlement = models::UserEntitlement::new();
+    entitlement.entitlement_base.access_level = Some(access_level);
+    entitlement.user = Some(user);
+
+    let response = client
+        .user_entitlements_client()
+        .add(organization.to_string(), entitlement)
+        .await?;
+
+    response
+        .user_entitlements_response_base
+        .user_entitlement
+        .ok_or_else(|| {
+            anyhow!("User was created, but response did not include entitlement details")
+        })
+}
+
+async fn resolve_user_id(
+    client: &member_entitlement_management::Client,
+    organization: &str,
+    id: &Option<String>,
+    email: &Option<String>,
+) -> Result<String> {
+    match (id.as_deref(), email.as_deref()) {
+        (Some(value), None) => Ok(value.to_string()),
+        (None, Some(value)) => {
+            let user = find_user_by_email(client, organization, value).await?;
+            user_id(&user)
+                .map(str::to_string)
+                .ok_or_else(|| anyhow!("Matched user is missing an entitlement ID"))
+        }
+        (Some(_), Some(_)) => Err(anyhow!("Use either --id or --email, not both")),
+        (None, None) => Err(anyhow!("Either --id or --email must be provided")),
+    }
+}
+
+async fn find_user_by_email(
+    client: &member_entitlement_management::Client,
+    organization: &str,
+    email: &str,
+) -> Result<models::UserEntitlement> {
+    let escaped_email = email.replace('\'', "''");
+    let filter = format!("name eq '{escaped_email}'");
+    let users = search_user_entitlements(client, organization, Some(filter)).await?;
+    let expected = normalize(email);
+
+    let mut matches = users
+        .into_iter()
+        .filter(|user| {
+            user_email(user)
+                .map(normalize)
+                .map(|current| current == expected)
+                .unwrap_or(false)
+        })
+        .collect::<Vec<_>>();
+
+    if matches.is_empty() {
+        return Err(anyhow!("No user found for email '{email}'"));
+    }
+
+    if matches.len() > 1 {
+        let candidate_ids = matches
+            .iter()
+            .map(|user| user_id(user).unwrap_or("-"))
+            .collect::<Vec<_>>();
+        return Err(anyhow!(
+            "Multiple users matched email '{email}'. Use --id instead. Candidates: {}",
+            candidate_ids.join(", ")
+        ));
+    }
+
+    Ok(matches.remove(0))
+}
+
+async fn search_user_entitlements(
+    client: &member_entitlement_management::Client,
+    organization: &str,
+    filter: Option<String>,
+) -> Result<Vec<models::UserEntitlement>> {
+    let mut users = Vec::new();
+    let mut continuation_token = None::<String>;
+
+    loop {
+        let mut request = client
+            .user_entitlements_client()
+            .search_user_entitlements(organization.to_string());
+
+        if let Some(token) = continuation_token.clone() {
+            request = request.continuation_token(token);
+        }
+
+        if let Some(ref filter_value) = filter {
+            request = request.filter(filter_value.clone());
+        }
+
+        let response = request.await?;
+        continuation_token = response.continuation_token.clone();
+        users.extend(response.items);
+
+        if continuation_token.is_none() {
+            break;
+        }
+    }
+
+    Ok(users)
+}
+
+fn normalize(value: &str) -> String {
+    value.trim().to_ascii_lowercase()
+}
+
+fn is_aad_group_added_user(user: &models::UserEntitlement) -> bool {
+    matches!(
+        user.entitlement_base
+            .access_level
+            .as_ref()
+            .and_then(|access| access.assignment_source.as_ref()),
+        Some(models::access_level::AssignmentSource::GroupRule)
+    )
+}
+
+fn user_id(user: &models::UserEntitlement) -> Option<&str> {
+    user.entitlement_base.id.as_deref()
+}
+
+fn user_email(user: &models::UserEntitlement) -> Option<&str> {
+    user.user
+        .as_ref()
+        .and_then(|graph_user| {
+            graph_user
+                .aad_graph_member
+                .graph_member
+                .principal_name
+                .as_deref()
+        })
+        .or_else(|| {
+            user.user.as_ref().and_then(|graph_user| {
+                graph_user
+                    .aad_graph_member
+                    .graph_member
+                    .mail_address
+                    .as_deref()
+            })
+        })
+}
+
+fn user_display_name(user: &models::UserEntitlement) -> Option<&str> {
+    user.user.as_ref().and_then(|graph_user| {
+        graph_user
+            .aad_graph_member
+            .graph_member
+            .graph_subject
+            .graph_subject_base
+            .display_name
+            .as_deref()
+    })
+}
+
+fn user_license(user: &models::UserEntitlement) -> String {
+    user.entitlement_base
+        .access_level
+        .as_ref()
+        .and_then(|access| access.account_license_type.as_ref())
+        .map(account_license_type_name)
+        .or_else(|| {
+            user.entitlement_base
+                .access_level
+                .as_ref()
+                .and_then(|access| access.license_display_name.clone())
+        })
+        .unwrap_or_else(|| "-".to_string())
+}
+
+fn account_license_type_name(value: &models::access_level::AccountLicenseType) -> String {
+    match value {
+        models::access_level::AccountLicenseType::None => "none".to_string(),
+        models::access_level::AccountLicenseType::EarlyAdopter => "earlyAdopter".to_string(),
+        models::access_level::AccountLicenseType::Express => "express".to_string(),
+        models::access_level::AccountLicenseType::Professional => "professional".to_string(),
+        models::access_level::AccountLicenseType::Advanced => "advanced".to_string(),
+        models::access_level::AccountLicenseType::Stakeholder => "stakeholder".to_string(),
+    }
+}
+
+fn display_users(users: &[models::UserEntitlement]) {
+    let filtered = users
+        .iter()
+        .filter(|user| !is_aad_group_added_user(user))
+        .collect::<Vec<_>>();
+
+    if filtered.is_empty() {
+        println!("No users found.");
+        return;
+    }
+
+    println!(
+        "{:<38} {:<35} {:<30} {:<14}",
+        "ID".bold(),
+        "Email".bold(),
+        "Display Name".bold(),
+        "License".bold()
+    );
+    println!("{}", "-".repeat(122));
+
+    for user in filtered {
+        println!(
+            "{:<38} {:<35} {:<30} {:<14}",
+            user_id(user).unwrap_or("-"),
+            user_email(user).unwrap_or("-"),
+            user_display_name(user).unwrap_or("-"),
+            user_license(user),
+        );
+    }
+}
+
+fn display_user_details(user: &models::UserEntitlement) {
+    println!("{}", "User Details".bold().underline());
+    println!("ID: {}", user_id(user).unwrap_or("-"));
+    println!("Email: {}", user_email(user).unwrap_or("-"));
+    println!("Display name: {}", user_display_name(user).unwrap_or("-"));
+    println!("License: {}", user_license(user));
+
+    if let Some(access_level) = user.entitlement_base.access_level.as_ref() {
+        if let Some(source) = access_level.assignment_source.as_ref() {
+            println!("Assignment source: {source:?}");
+        }
+        if let Some(status) = access_level.status.as_ref() {
+            println!("Status: {status:?}");
+        }
+    }
+
+    if let Some(date_created) = user.entitlement_base.date_created.as_ref() {
+        println!("Created: {date_created}");
+    }
+
+    if let Some(last_accessed) = user.entitlement_base.last_accessed_date.as_ref() {
+        println!("Last accessed: {last_accessed}");
+    }
+}
+
+async fn update_user_license(
+    organization: &str,
+    pat: &str,
+    user_id: &str,
+    license: UserLicenseType,
+) -> Result<()> {
+    let payload = json!([
+        {
+            "op": "replace",
+            "path": "/accessLevel",
+            "value": {
+                "accountLicenseType": license.as_api_value(),
+                "licensingSource": "account",
+                "msdnLicenseType": "none",
+                "licenseDisplayName": license.as_api_value()
+            }
+        }
+    ]);
+
+    let url = format!(
+        "https://vsaex.dev.azure.com/{organization}/_apis/userentitlements/{user_id}?api-version=7.1-preview"
+    );
+
+    let response = reqwest::Client::new()
+        .patch(url)
+        .basic_auth("", Some(pat))
+        .header(CONTENT_TYPE, "application/json-patch+json")
+        .json(&payload)
+        .send()
+        .await?;
+
+    if response.status().is_success() {
+        return Ok(());
+    }
+
+    let status = response.status();
+    let body = response.text().await.unwrap_or_default();
+    Err(anyhow!(
+        "Failed to update license for user '{user_id}' ({status}): {body}"
+    ))
+}


### PR DESCRIPTION
Adds a new `user` root command for organization-level user management.

What changed:
- Adds `user add`, `user list`, `user remove`, `user show`, and `user update`
- Supports lookup by either `--id` or `--email` for show/remove/update
- Uses Azure DevOps member entitlement APIs for user and license management
- Excludes users inherited through AAD group rules from `user list`
- Updates README usage docs and command listings

Notes:
- License input uses the raw Azure DevOps account license values: `none`, `earlyAdopter`, `express`, `professional`, `advanced`, `stakeholder`
- `user update` patches entitlement access levels directly through the member entitlement management API